### PR TITLE
Add config option to ingore rules per file

### DIFF
--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -73,9 +73,9 @@ def run():
         return 1
 
     # Collect the rules from the configution
-    rules = RulesCollection()
+    rules = RulesCollection(config)
     for rulesdir in config.rulesdirs:
-        rules.extend(RulesCollection.create_from_directory(rulesdir))
+        rules.extend(RulesCollection.create_from_directory(rulesdir, config))
 
     # Show the rules listing
     if options.listrules:
@@ -91,9 +91,7 @@ def run():
     matches = list()
     checked_files = set()
     for state in states:
-        runner = Runner(rules, state, config.tags,
-                        config.skip_list, config.exclude_paths,
-                        config.verbosity, checked_files)
+        runner = Runner(rules, state, config, checked_files)
         matches.extend(runner.run())
 
     # Sort the matches

--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -8,8 +8,7 @@ import optparse
 import sys
 
 from saltlint import formatters, NAME, VERSION
-from saltlint.linter import default_rulesdir
-from saltlint.config import SaltLintConfig, SaltLintConfigError
+from saltlint.config import SaltLintConfig, SaltLintConfigError, default_rulesdir
 from saltlint.linter import RulesCollection, Runner
 
 
@@ -58,11 +57,12 @@ def run():
                            ' is repeatable.',
                       default=[])
     parser.add_option('-c', help='Specify configuration file to use.  Defaults to ".salt-lint"')
-    options, args = parser.parse_args(sys.argv[1:])
+    (options, args) = parser.parse_args(sys.argv[1:])
 
     # Read, parse and validate the configration
+    options_dict = vars(options)
     try:
-        config = SaltLintConfig(options)
+        config = SaltLintConfig(options_dict)
     except SaltLintConfigError as exc:
         print(exc)
         return 2

--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -12,7 +12,7 @@ from saltlint.config import SaltLintConfig, SaltLintConfigError, default_rulesdi
 from saltlint.linter import RulesCollection, Runner
 
 
-def run():
+def run(args=None):
     formatter = formatters.Formatter()
 
     parser = optparse.OptionParser("%prog [options] init.sls [state ...]",
@@ -57,7 +57,7 @@ def run():
                            ' is repeatable.',
                       default=[])
     parser.add_option('-c', help='Specify configuration file to use.  Defaults to ".salt-lint"')
-    (options, args) = parser.parse_args(sys.argv[1:])
+    (options, parsed_args) = parser.parse_args(args if args is not None else sys.argv[1:])
 
     # Read, parse and validate the configration
     options_dict = vars(options)
@@ -68,7 +68,7 @@ def run():
         return 2
 
     # Show a help message on the screen
-    if len(args) == 0 and not (options.listrules or options.listtags):
+    if len(parsed_args) == 0 and not (options.listrules or options.listtags):
         parser.print_help(file=sys.stderr)
         return 1
 
@@ -87,7 +87,7 @@ def run():
         print(rules.listtags())
         return 0
 
-    states = set(args)
+    states = set(parsed_args)
     matches = list()
     checked_files = set()
     for state in states:

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -43,7 +43,7 @@ class SaltLintConfig(object):
                 raise SaltLintConfigError("invalid config: {}".format(exc))
 
         # Parse verbosity
-        self.verbosity = self._options.verbosity
+        self.verbosity = self._options.verbosity if self._options.verbosity else 0
         if 'verbosity' in config:
             self.verbosity += config['verbosity']
 

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Roald Nefs
+
+import yaml
+import os
+
+# Import Salt libs
+from salt.ext import six
+
+from saltlint.linter import default_rulesdir
+
+
+class SaltLintConfigError(Exception):
+    pass
+
+
+class SaltLintConfig(object):
+
+    def __init__(self, options):
+        self._options = options
+        # Configuration file to use, defaults to ".salt-lint".
+        file = options.c if options.c else '.salt-lint'
+
+        # Read the file contents
+        if os.path.exists(file):
+            with open(file, 'r') as f:
+                content = f.read()
+        else:
+            content = None
+
+        # Parse the content of the file as YAML
+        self._parse(content)
+        self._validate()
+
+    def _parse(self, content):
+        config = dict()
+
+        # Parse the YAML content
+        if content:
+            try:
+                config = yaml.safe_load(content)
+            except Exception as exc:
+                raise SaltLintConfigError("invalid config: {}".format(exc))
+
+        # Parse verbosity
+        self.verbosity = self._options.verbosity
+        if 'verbosity' in config:
+            self.verbosity += config['verbosity']
+
+        # Parse exclude paths
+        self.exclude_paths = self._options.exclude_paths
+        if 'exclude_paths' in config:
+            self.exclude_paths += config['exclude_paths']
+
+        # Parse skip list
+        skip_list = self._options.skip_list
+        if 'skip_list' in config:
+            skip_list += config['skip_list']
+        skip = set()
+        for s in skip_list:
+            skip.update(str(s).split(','))
+        self.skip_list = frozenset(skip)
+
+        # Parse tags
+        self.tags = self._options.tags
+        if 'tags' in config:
+            self.tags += config['tags']
+        if isinstance(self.tags, six.string_types):
+            self.tags = self.tags.split(',')
+
+        # Parse use default rules
+        use_default_rules = self._options.use_default_rules
+        if 'use_default_rules' in config:
+            use_default_rules = use_default_rules or config['use_default_rules']
+
+        # Parse rulesdir
+        rulesdir = self._options.rulesdir
+        if 'rulesdir' in config:
+            rulesdir += config['rulesdir']
+
+        # Determine the rules directories
+        if use_default_rules:
+            self.rulesdirs = rulesdir + [default_rulesdir]
+        else:
+            self.rulesdirs = rulesdir or [default_rulesdir]
+
+        # Parse colored
+        self.colored = self._options.colored
+
+    def _validate(self):
+        pass

--- a/saltlint/linter.py
+++ b/saltlint/linter.py
@@ -16,12 +16,9 @@ from salt.ext import six
 import saltlint.utils
 
 
-default_rulesdir = os.path.join(os.path.dirname(saltlint.utils.__file__), 'rules')
-
-
 class SaltLintRule(object):
 
-    def __init__(self, config):
+    def __init__(self, config=None):
         self.config = config
 
     def __repr__(self):
@@ -78,7 +75,7 @@ class SaltLintRule(object):
 
 class RulesCollection(object):
 
-    def __init__(self, config):
+    def __init__(self, config=None):
         self.rules = []
         self.config = config
 

--- a/saltlint/utils.py
+++ b/saltlint/utils.py
@@ -7,7 +7,7 @@ import imp
 import os
 
 
-def load_plugins(directory):
+def load_plugins(directory, config):
     result = []
     fh = None
 
@@ -17,7 +17,7 @@ def load_plugins(directory):
         try:
             fh, filename, desc = imp.find_module(pluginname, [directory])
             mod = imp.load_module(pluginname, fh, filename, desc)
-            obj = getattr(mod, pluginname)()
+            obj = getattr(mod, pluginname)(config)
             result.append(obj)
         finally:
             if fh:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     },
     include_package_data=True,
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    install_requires=['salt'],
+    install_requires=['salt', 'pathspec>=0.6.0'],
     license=__license__,
     zip_safe=False,
     classifiers=[

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@
 import tempfile
 
 from saltlint.linter import Runner
+from saltlint.config import SaltLintConfig
 
 
 class RunFromText(object):
@@ -14,7 +15,7 @@ class RunFromText(object):
         self.collection = collection
 
     def _call_runner(self, path):
-        runner = Runner(self.collection, path, [], [], [])
+        runner = Runner(self.collection, path, SaltLintConfig({}))
         return runner.run()
 
     def run_state(self, state_text):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,7 +15,7 @@ class RunFromText(object):
         self.collection = collection
 
     def _call_runner(self, path):
-        runner = Runner(self.collection, path, SaltLintConfig({}))
+        runner = Runner(self.collection, path, SaltLintConfig())
         return runner.run()
 
     def run_state(self, state_text):

--- a/tests/unit/TestConfig.py
+++ b/tests/unit/TestConfig.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Roald Nefs
+
+import unittest
+import tempfile
+
+from saltlint.config import SaltLintConfig
+
+
+SALT_LINT_CONFIG = '''
+---
+exclude_paths:
+  - exclude_this_file
+  - exclude_this_directory/
+  - exclude/this/sub-directory/
+skip_list:
+  - 207
+  - 208
+tags:
+  - formatting
+verbosity: 1
+rules:
+  formatting:
+    ignore: |
+      tests/test-extension-failure
+      tests/**/*.jinja
+'''
+
+class TestConfig(unittest.TestCase):
+
+    def setUp(self):
+        # Open the temporary configuration file and write the contents of
+        # SALT_LINT_CONFIG to the temporary file.
+        fp = tempfile.NamedTemporaryFile()
+        fp.write(SALT_LINT_CONFIG.encode())
+        fp.seek(0)
+        self.fp = fp
+
+        # Specify the temporary file as if it wass passed as a command line
+        # argument.
+        self.config = SaltLintConfig(dict(c = self.fp.name))
+
+    def tearDown(self):
+        # Close the temporary configuration file.
+        self.fp.close()
+
+    def test_config(self):
+        # Check 'verbosity'
+        self.assertEqual(self.config.verbosity, 1)
+
+        # Check 'skip_list'
+        self.assertIn('208', self.config.skip_list)
+        self.assertNotIn('200', self.config.skip_list)
+
+        # Check 'exclude_paths'
+        self.assertIn('exclude_this_file', self.config.exclude_paths)
+        self.assertEqual(3, len(self.config.exclude_paths))
+
+    def test_is_file_ignored(self):
+        # Check basic ignored rules per file
+        self.assertTrue(
+            self.config.is_file_ignored('tests/test-extension-failure', 'formatting')
+        )
+        self.assertFalse(
+            self.config.is_file_ignored('tests/test-extension-failure', '210')
+        )
+        # Check more complex ignored rules per file using gitwildmatches
+        self.assertTrue(
+            self.config.is_file_ignored('tests/other/test.jinja', 'formatting')
+        )
+        self.assertFalse(
+            self.config.is_file_ignored('test.jinja', 'formatting')
+        )
+
+

--- a/tests/unit/TestFileExtension.py
+++ b/tests/unit/TestFileExtension.py
@@ -3,6 +3,7 @@
 
 import unittest
 
+from saltlint.config import SaltLintConfig
 from saltlint.linter import Runner, RulesCollection
 from saltlint.rules.FileExtensionRule import FileExtensionRule
 
@@ -15,11 +16,11 @@ class TestLineTooLongRule(unittest.TestCase):
 
     def test_file_positive(self):
         path = 'tests/test-extension-success.sls'
-        runner = Runner(self.collection, path, [], [], [])
+        runner = Runner(self.collection, path, SaltLintConfig({}))
         self.assertEqual([], runner.run())
 
     def test_file_negative(self):
         path = 'tests/test-extension-failure'
-        runner = Runner(self.collection, path, [], [], [])
+        runner = Runner(self.collection, path, SaltLintConfig({}))
         errors = runner.run()
         self.assertEqual(1, len(errors))

--- a/tests/unit/TestFileExtension.py
+++ b/tests/unit/TestFileExtension.py
@@ -16,11 +16,11 @@ class TestLineTooLongRule(unittest.TestCase):
 
     def test_file_positive(self):
         path = 'tests/test-extension-success.sls'
-        runner = Runner(self.collection, path, SaltLintConfig({}))
+        runner = Runner(self.collection, path, SaltLintConfig())
         self.assertEqual([], runner.run())
 
     def test_file_negative(self):
         path = 'tests/test-extension-failure'
-        runner = Runner(self.collection, path, SaltLintConfig({}))
+        runner = Runner(self.collection, path, SaltLintConfig())
         errors = runner.run()
         self.assertEqual(1, len(errors))

--- a/tests/unit/TestRunner.py
+++ b/tests/unit/TestRunner.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Roald Nefs
+
+import unittest
+
+from saltlint.cli import run
+
+class TestRunner(unittest.TestCase):
+
+    def test_runner_with_matches(self):
+        # Check the integer returned by saltlint.cli.run(), when matches are
+        # expected.
+        args = ['tests/test-extension-failure']
+        self.assertEqual(run(args), 2)
+
+    def test_runner_without_matches(self):
+        # Check the integer returned by saltlint.cli.run(), when no matches are
+        # expected.
+        args = ['tests/test-extension-success.sls']
+        self.assertEqual(run(args), 0)


### PR DESCRIPTION
Add configuration option to ignore rules per file, e.g.:

```yaml
---
rules:
  formatting:
    ignore: |
      first.sls
      second.sls
  210:
    ignore: |
      state/*.sls
      *.jinja
```

This PR also moves configuration parsing from `cli.py` to `config.py`. This makes `cli.py` less complex and allows the program to only pass the config object instead of having to pass the updated options.

Fixes #48.