### PR TITLE
Fix 210 to skip non-number values

### DIFF
--- a/saltlint/rules/YamlHasOctalValueRule.py
+++ b/saltlint/rules/YamlHasOctalValueRule.py
@@ -15,7 +15,7 @@ class YamlHasOctalValueRule(SaltLintRule):
     tags = ['formatting']
     version_added = 'v0.0.6'
 
-    bracket_regex = re.compile(r": (?<!['\"])0+[0-9]\d*(?!['\"])")
+    bracket_regex = re.compile(r"(?<=:)\s{0,}0[0-9]{1,}\s{0,}((?={#)|(?=#)|(?=$))")
 
     def match(self, file, line):
         return self.bracket_regex.search(line)


### PR DESCRIPTION
Fix rule 210 to skip unquoted non-number values (e.g. `000-default`) as they aren't octal values but strings.

This commit also allows optional whitespace around the unquoted octal value, and the value followed by a YAML or JINJA comment (e.g. `0700 {# JINJA COMMENT #}`).

Fixes #68.