### PR TITLE
 Version 0.0.10 Release

### DIFF
--- a/saltlint/__init__.py
+++ b/saltlint/__init__.py
@@ -5,9 +5,9 @@
 """
 
 NAME = 'salt-lint'
-VERSION = '0.0.9'
+VERSION = '0.0.10'
 DESCRIPTION = __doc__
 
-__author__ = 'Roald Nefs'
+__author__ = 'Warpnet B.V.'
 __license__ = 'MIT'
 __version__ = VERSION

--- a/saltlint/rules/JinjaCommentHasSpacesRule.py
+++ b/saltlint/rules/JinjaCommentHasSpacesRule.py
@@ -12,7 +12,7 @@ class JinjaCommentHasSpacesRule(SaltLintRule):
     shortdesc = 'Jinja comment should have spaces before and after: {# comment #}'
     description = 'Jinja comment should have spaces before and after: ``{# comment #}``'
     severity = 'LOW'
-    tags = ['formatting']
+    tags = ['formatting', 'jinja']
     version_added = 'v0.0.5'
 
     bracket_regex = re.compile(r"{#[^ \-\+]|{#[\-\+][^ ]|[^ \-\+]#}|[^ ][\-\+]#}")

--- a/saltlint/rules/JinjaPillarGrainsGetFormatRule.py
+++ b/saltlint/rules/JinjaPillarGrainsGetFormatRule.py
@@ -14,7 +14,7 @@ class JinjaPillarGrainsGetFormatRule(SaltLintRule):
                   " like salt['pillar.get']('item') or grains['item1']"
     severity = 'HIGH'
     tags = ['formatting', 'jinja']
-    version_added = 'develop'
+    version_added = 'v0.0.10'
 
     bracket_regex = re.compile(r"{{( |\-|\+)?.(pillar|grains).get\(.+}}")
 

--- a/saltlint/rules/JinjaStatementHasSpacesRule.py
+++ b/saltlint/rules/JinjaStatementHasSpacesRule.py
@@ -12,7 +12,7 @@ class JinjaStatementHasSpacesRule(SaltLintRule):
     shortdesc = 'Jinja statement should have spaces before and after: {% statement %}'
     description = 'Jinja statement should have spaces before and after: ``{% statement %}``'
     severity = 'LOW'
-    tags = ['formatting']
+    tags = ['formatting', 'jinja']
     version_added = 'v0.0.2'
 
     bracket_regex = re.compile(r"{%[^ \-\+]|{%[\-\+][^ ]|[^ \-\+]%}|[^ ][\-\+]%}")

--- a/saltlint/rules/JinjaVariableHasSpacesRule.py
+++ b/saltlint/rules/JinjaVariableHasSpacesRule.py
@@ -12,7 +12,7 @@ class JinjaVariableHasSpacesRule(SaltLintRule):
     shortdesc = 'Jinja variables should have spaces before and after: {{ var_name }}'
     description = 'Jinja variables should have spaces before and after: ``{{ var_name }}``'
     severity = 'LOW'
-    tags = ['formatting']
+    tags = ['formatting', 'jinja']
     version_added = 'v0.0.1'
 
     bracket_regex = re.compile(r"{{[^ \-\+]|{{[-\+][^ ]|[^ \-\+]}}|[^ ][-\+]}}")


### PR DESCRIPTION
### Introduction
Version `v0.0.10` release, requires to be tagged after being merged into `master`.

### Added
- Add rule `211` to check for faulty usage of `grains.get` or `pillar.get` (#60).
- Add configuration option to ignore rules per file (#67).

### Changed
- Changed author to Warpnet B.V. (#61).
- Change `README` to Markdown format (#65).
- Refactor the way the configuration is parsed (#67).
- Group Jinja rules under the tag `jinja` (332413d).

### Fixed
- Fix rule `210` to skip non-number values (#69). 

Closes #48, #57, #58, #61, #64, #68.