### PR TITLE
Fix utf-8 encoding

### DIFF
--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -99,7 +99,7 @@ def run(args=None):
 
     # Show the matches on the screen
     for match in matches:
-        print(formatter.format(match, config.colored))
+        print(formatter.format(match, config.colored).encode('utf-8'))
 
     # Return the exit code
     if len(matches):


### PR DESCRIPTION
This PR fixes UTF-8 encoding under python2 when salt-lint is piped to another program.

This fixes  #74