### PR TITLE
Add JSON Formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,12 @@ Options:
   -L                    list all the rules
   -r RULESDIR           specify one or more rules directories using one or
                         more -r arguments. Any -r flags override the default
-                        rules in
-                        /home/roald/workspace/github.com/roaldnefs/salt-
-                        lint/saltlint/rules, unless -R is also used.
+                        rules in /path/to/salt-lint/saltlint/rules, unless 
+                        -R is also used.
   -R                    Use default rules in
-                        /home/roald/workspace/github.com/roaldnefs/salt-
-                        lint/saltlint/rules in addition to any extra rules
-                        directories specified with -r. There is no need to
-                        specify this if no -r flags are used.
+                        /path/to/salt-lint/saltlint/rules in addition to any
+                        extra rules directories specified with -r. There is
+                        no need to specify this if no -r flags are used.
   -t TAGS               only check rules whose id/tags match these values
   -T                    list all the tags
   -v                    Increase verbosity level
@@ -55,6 +53,7 @@ Options:
   --exclude=EXCLUDE_PATHS
                         path to directories or files to skip. This option is
                         repeatable.
+  --json                parse the output as JSON
   -c C                  Specify configuration file to use.  Defaults to
                         ".salt-lint"
 ```

--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -13,8 +13,6 @@ from saltlint.linter import RulesCollection, Runner
 
 
 def run(args=None):
-    formatter = formatters.Formatter()
-
     parser = optparse.OptionParser("%prog [options] init.sls [state ...]",
                                    version='{} {}'.format(NAME, VERSION))
 
@@ -56,6 +54,8 @@ def run(args=None):
                       help='path to directories or files to skip. This option'
                            ' is repeatable.',
                       default=[])
+    parser.add_option('--json', dest='json', action='store_true', default=False,
+                      help='parse the output as JSON')
     parser.add_option('-c', help='Specify configuration file to use.  Defaults to ".salt-lint"')
     (options, parsed_args) = parser.parse_args(args if args is not None else sys.argv[1:])
 
@@ -87,6 +87,12 @@ def run(args=None):
         print(rules.listtags())
         return 0
 
+    # Define the formatter
+    if config.json:
+        formatter = formatters.JsonFormatter()
+    else:
+        formatter = formatters.Formatter()
+
     states = set(parsed_args)
     matches = list()
     checked_files = set()
@@ -98,8 +104,7 @@ def run(args=None):
     matches.sort(key=lambda x: (x.filename, x.linenumber, x.rule.id))
 
     # Show the matches on the screen
-    for match in matches:
-        print(formatter.format(match, config.colored))
+    formatter.process(matches, config.colored)
 
     # Return the exit code
     if len(matches):

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -95,6 +95,9 @@ class SaltLintConfig(object):
             hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
         )
 
+        # Parse json
+        self.json = self._options.get('json', False)
+        
         # Parse rule specific configuration, the configration can be listed by
         # the rule ID and/or tag.
         self.rules = dict()

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -97,7 +97,7 @@ class SaltLintConfig(object):
 
         # Parse json
         self.json = self._options.get('json', False)
-        
+
         # Parse rule specific configuration, the configration can be listed by
         # the rule ID and/or tag.
         self.rules = dict()

--- a/saltlint/formatters/__init__.py
+++ b/saltlint/formatters/__init__.py
@@ -16,7 +16,7 @@ class Formatter(object):
 
     def process(self, matches, colored=False):
         for match in matches:
-            print(self.format(match, colored).encode('utf-8'))
+            print(self.format(match, colored))
 
     def format(self, match, colored=False):
         formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"

--- a/saltlint/formatters/__init__.py
+++ b/saltlint/formatters/__init__.py
@@ -55,5 +55,6 @@ class JsonFormatter(object):
             'message': match.message,
             'filename': match.filename,
             'linenumber': match.linenumber,
-            'line': match.line
+            'line': match.line,
+            'severity': match.rule.severity,
         }

--- a/saltlint/formatters/__init__.py
+++ b/saltlint/formatters/__init__.py
@@ -40,6 +40,7 @@ class Formatter(object):
                                     match.linenumber,
                                     match.line)
 
+
 class JsonFormatter(object):
 
     def process(self, matches, *args, **kwargs):

--- a/saltlint/formatters/__init__.py
+++ b/saltlint/formatters/__init__.py
@@ -16,7 +16,7 @@ class Formatter(object):
 
     def process(self, matches, colored=False):
         for match in matches:
-            print(self.format(match, colored))
+            print(self.format(match, colored).encode('utf-8'))
 
     def format(self, match, colored=False):
         formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"

--- a/saltlint/formatters/__init__.py
+++ b/saltlint/formatters/__init__.py
@@ -1,6 +1,9 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2013-2018 Will Thames <will@thames.id.au>
 # Copyright (c) 2018 Ansible by Red Hat
 # Modified work Copyright (c) 2019 Roald Nefs
+
+import json
 
 # Import salt libs
 try:
@@ -10,6 +13,10 @@ except ImportError:
 
 
 class Formatter(object):
+
+    def process(self, matches, colored=False):
+        for match in matches:
+            print(self.format(match, colored))
 
     def format(self, match, colored=False):
         formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"
@@ -32,3 +39,20 @@ class Formatter(object):
                                     match.filename,
                                     match.linenumber,
                                     match.line)
+
+class JsonFormatter(object):
+
+    def process(self, matches, *args, **kwargs):
+        items = []
+        for match in matches:
+            items.append(self.format(match))
+        print(json.dumps(items))
+
+    def format(self, match):
+        return {
+            'id': match.rule.id,
+            'message': match.message,
+            'filename': match.filename,
+            'linenumber': match.linenumber,
+            'line': match.line
+        }


### PR DESCRIPTION
Add JSON formatter to make it easier to interpret the output of `salt-lint`. When using the `--json` flag the output will be similar to:

```json
[{
	"id": "205",
	"message": "Use \".sls\" as a Salt State file extension",
	"filename": "tests/test-extension-failure",
	"linenumber": 1,
	"line": "tempfile:",
	"severity": "MEDIUM"
}, {
	"id": "212",
	"message": "Most files should not contain irregular spaces",
	"filename": "tests/test-extension-failure",
	"linenumber": 3,
	"line": "    - test:\u00a0test",
	"severity": "LOW"
}]
```

Fixes #80.