### PR TITLE
Fix encoding to use utf-8

### DIFF
--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -8,6 +8,7 @@ import optparse
 import os
 import sys
 import tempfile
+import codecs
 
 from saltlint import formatters, NAME, VERSION
 from saltlint.config import SaltLintConfig, SaltLintConfigError, default_rulesdir
@@ -15,6 +16,12 @@ from saltlint.linter import RulesCollection, Runner
 
 
 def run(args=None):
+    # Wrap `sys.stdout` in an object that automatically encodes an unicode
+    # string into utf-8, in Python 2 only. The default encoding for Python 3
+    # is already utf-8.
+    if sys.version_info[0] < 3:
+        sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
+
     formatter = formatters.Formatter()
 
     parser = optparse.OptionParser("%prog [options] init.sls [state ...]",
@@ -110,7 +117,7 @@ def run(args=None):
 
     # Show the matches on the screen
     for match in matches:
-        print(formatter.format(match, config.colored).encode('utf-8'))
+        print(formatter.format(match, config.colored))
 
     # Delete stdin temporary file
     if stdin_state:


### PR DESCRIPTION
Fix encoding to use utf-8 by default in Python 2, the default encoding in Python 3 is already utf-8. This fix will wrap `sys.stdout` in a object that automatically encodes an unicode string into utf-8, in Python 2 only.

An alternative to this would be to set the `PYTHONIOENCODING='utf-8'` environment variable before running `salt-lint`, but this would require an extra action on the user side.

The old solution using `str.encode('utf-8')` caused byte string (e.g. `b''`) output in Python 3...

Fixes #74.