### PR TITLE
Fix format string to use square brackets

### DIFF
--- a/saltlint/formatters/__init__.py
+++ b/saltlint/formatters/__init__.py
@@ -34,11 +34,12 @@ class Formatter(object):
                 u'{0}{1}{2}'.format(color['MAGENTA'], match.line, color['ENDC'])
             )
         else:
-            return formatstr.format(match.rule.id,
-                                    match.message,
-                                    match.filename,
-                                    match.linenumber,
-                                    match.line)
+            return formatstr.format(
+                u'[{0}]'.format(match.rule.id),
+                match.message,
+                match.filename,
+                match.linenumber,
+                match.line)
 
 
 class JsonFormatter(object):


### PR DESCRIPTION
Fix format string to also use square brackets with the `--nocolor` option.

Fixes #86.