### PR TITLE
Version 0.1.0 Release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ MIT License
 
 Copyright (c) 2013-2018 Will Thames <will@thames.id.au>
 Copyright (c) 2018 Ansible by Red Hat
-Modified work Copyright (c) 2019 Roald Nefs
+Modified work Copyright (c) 2019 Warpnet B.V.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="info@warpnet.nl"
 RUN apk add --no-cache gcc g++ build-base libzmq musl-dev zeromq-dev
 
 # Install the salt-lint package
-RUN pip install --no-cache salt-lint==v0.0.10
+RUN pip install --no-cache salt-lint==v0.1.0
 
 # Remove development utilities
 RUN apk del --no-cache gcc g++ build-base libzmq musl-dev zeromq-dev \

--- a/saltlint/__init__.py
+++ b/saltlint/__init__.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2019 Roald Nefs
+# Copyright (c) 2019 Warpnet B.V.
 
 """A command-line utility that checks for best practices in SaltStack.
 """
 
 NAME = 'salt-lint'
-VERSION = '0.0.10'
+VERSION = '0.1.0'
 DESCRIPTION = __doc__
 
 __author__ = 'Warpnet B.V.'

--- a/saltlint/rules/NoIrregularSpacesRule.py
+++ b/saltlint/rules/NoIrregularSpacesRule.py
@@ -9,7 +9,7 @@ class NoIrregularSpacesRule(SaltLintRule):
     description = 'Irregular spaces can cause unexpected display issues, use spaces'
     severity = 'LOW'
     tags = ['formatting']
-    version_added = 'develop'
+    version_added = 'v0.1.0'
 
     irregular_spaces = [
         u"\u000B",  # Line Tabulation (\v) - <VT>


### PR DESCRIPTION
### Introduction
Version `v0.1.0` release, requires to be tagged after being merged into `master`.

### Added

- Add rule `212` to check for irregular spaces (#76).
- Add initial `Dockerfile` for `salt-lint` (#77).
- Add option to output in JSON format (#80).
- Add option to read from standard input (#79).
- Add overview of all rules in `README.md` (#82).

### Fixed

- Fix output encoding when using Python 2 (#74).
- Fix format string to use square brackets with the `--nocolor` option (#86).

