### PR TITLE
Fix typos in saltlint/linter.py

### DIFF
--- a/saltlint/linter.py
+++ b/saltlint/linter.py
@@ -100,7 +100,7 @@ class RulesCollection(object):
             with codecs.open(statefile['path'], mode='rb', encoding='utf-8') as f:
                 text = f.read()
         except IOError as e:
-            print("WARNING: Coudn't open %s - %s" %
+            print("WARNING: Couldn't open %s - %s" %
                   (statefile['path'], e.strerror),
                   file=sys.stderr)
             return matches
@@ -111,7 +111,7 @@ class RulesCollection(object):
                 rule_definition = set(rule.tags)
                 rule_definition.add(rule.id)
 
-                # Check if the the file is in the rule specific ignore list.
+                # Check if the file is in the rule specific ignore list.
                 for definition in rule_definition:
                     if self.config.is_file_ignored(statefile['path'], definition):
                         skip = True


### PR DESCRIPTION
Fix typos in `saltlint/linter.py`, as pointed out by @hbokh in https://github.com/warpnet/salt-lint/issues/100#issuecomment-552614281. 