### PR TITLE
Change exclude path(s) to use pathspec

### DIFF
--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -60,7 +60,7 @@ def run(args=None):
                       action='store_true',
                       help="Try force colored output (relying on salt's code)")
     parser.add_option('--exclude', dest='exclude_paths', action='append',
-                      help='path to directories or files to skip. This option'
+                      help='Path to directories or files to skip. This option'
                            ' is repeatable.',
                       default=[])
     parser.add_option('--json', dest='json', action='store_true', default=False,

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -53,9 +53,12 @@ class SaltLintConfig(object):
             self.verbosity += config['verbosity']
 
         # Parse exclude paths
-        self.exclude_paths = self._options.get('exclude_paths', [])
+        exclude_paths = self._options.get('exclude_paths', [])
         if 'exclude_paths' in config:
-            self.exclude_paths += config['exclude_paths']
+            exclude_paths += config['exclude_paths']
+        self.exclude_paths = pathspec.PathSpec.from_lines(
+            'gitwildmatch', exclude_paths
+        )
 
         # Parse skip list
         skip_list = self._options.get('skip_list', [])

--- a/saltlint/linter.py
+++ b/saltlint/linter.py
@@ -176,26 +176,16 @@ class Runner(object):
         self.tags = config.tags
         self.skip_list = config.skip_list
         self.verbosity = config.verbosity
-        self._update_exclude_paths(config.exclude_paths)
+        self.exclude_paths = config.exclude_paths
 
         # Set the checked files
         if checked_files is None:
             checked_files = set()
         self.checked_files = checked_files
 
-    def _update_exclude_paths(self, exclude_paths):
-        if exclude_paths:
-            # These will be (potentially) relative paths
-            paths = [s.strip() for s in exclude_paths]
-            self.exclude_paths = paths + [os.path.abspath(p) for p in paths]
-        else:
-            self.exclude_paths = []
-
     def is_excluded(self, file_path):
-        # Any will short-circuit as soon as something returns True, but will
-        # be poor performance for the case where the path under question is
-        # not excluded.
-        return any(file_path.startswith(path) for path in self.exclude_paths)
+        # Check if the file path matches one of the exclude paths
+        return self.exclude_paths.match_file(file_path)
 
     def run(self):
         files = list()


### PR DESCRIPTION
Change the exclude path(s) option and configuration to use pathspec. This allows the paths to be matched on Git's wildmatch pattern. Git uses wildmatch for its [gitignore](http://git-scm.com/docs/gitignore) files.

Fixes #100.