### PR TITLE
Change optparse to argparse

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -60,8 +60,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=deprecated-module,
-        duplicate-code,
+disable=duplicate-code,
         invalid-name,
         missing-docstring,
         no-self-use,

--- a/README.md
+++ b/README.md
@@ -29,34 +29,42 @@ pip install git+https://github.com/warpnet/salt-lint.git
 The following is the output from `salt-lint --help`, providing an overview of the basic command line options:
 
 ```bash
-Usage: salt-lint [options] init.sls [state ...]
+usage: salt-lint [-h] [--version] [-L] [-r RULESDIR] [-R] [-t TAGS] [-T] [-v]
+                 [-x SKIP_LIST] [--nocolor] [--force-color]
+                 [--exclude EXCLUDE_PATHS] [--json] [--severity] [-c C]
+                 [state [state ...]]
 
-Options:
-  --version             show program's version number and exit
+positional arguments:
+  state                 Specify one or more states to lint.
+
+optional arguments:
   -h, --help            show this help message and exit
-  -L                    list all the rules
-  -r RULESDIR           specify one or more rules directories using one or
+  --version             show program's version number and exit
+  -L                    List all the rules.
+  -r RULESDIR           Specify one or more rules directories using one or
                         more -r arguments. Any -r flags override the default
-                        rules in /path/to/salt-lint/saltlint/rules, unless
-                        -R is also used.
-  -R                    Use default rules in
-                        /path/to/salt-lint/saltlint/rules in addition to any
-                        extra rules directories specified with -r. There is
-                        no need to specify this if no -r flags are used.
-  -t TAGS               only check rules whose id/tags match these values
-  -T                    list all the tags
-  -v                    Increase verbosity level
-  -x SKIP_LIST          only check rules whose id/tags do not match these
-                        values
-  --nocolor             disable colored output
-  --force-color         Try force colored output (relying on salt's code)
-  --exclude=EXCLUDE_PATHS
-                        path to directories or files to skip. This option is
+                        rules in /path/to/salt-lint/saltlint/rules, unless -R
+                        is also used.
+  -R                    Use default rules in /path/to/salt-lint/saltlint/rules
+                        in addition to any extra rules directories specified
+                        with -r. There is no need to specify this if no -r
+                        flags are used.
+  -t TAGS               Only check rules whose id/tags match these values.
+  -T                    List all the tags.
+  -v                    Increase verbosity level.
+  -x SKIP_LIST          Only check rules whose id/tags do not match these
+                        values.
+  --nocolor, --nocolour
+                        Disable colored output.
+  --force-color, --force-colour
+                        Try force colored output (relying on salt's code).
+  --exclude EXCLUDE_PATHS
+                        Path to directories or files to skip. This option is
                         repeatable.
-  --json                parse the output as JSON
-  --severity            add the severity to the standard output
-  -c C                  Specify configuration file to use.  Defaults to
-                        ".salt-lint"
+  --json                Parse the output as JSON.
+  --severity            Add the severity to the standard output.
+  -c C                  Specify configuration file to use. Defaults to ".salt-
+                        lint".
 ```
 
 ## Linting Salt State files

--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -27,51 +27,58 @@ def run(args=None):
                         version='{} {}'.format(NAME, VERSION))
 
     parser.add_argument('-L', dest='listrules', default=False,
-                        action='store_true', help="list all the rules")
+                        action='store_true', help="List all the rules.")
     parser.add_argument('-r', action='append', dest='rulesdir',
                         default=[], type=str,
-                        help="specify one or more rules directories using "
+                        help="Specify one or more rules directories using "
                              "one or more -r arguments. Any -r flags override "
                              "the default rules in %s, unless -R is also used."
                         % default_rulesdir)
     parser.add_argument('-R', action='store_true', default=False,
                         dest='use_default_rules',
-                        help="Use default rules in %s in addition to any extra "
-                             "rules directories specified with -r. There is "
-                             "no need to specify this if no -r flags are used."
+                        help="Use default rules in %s in addition to any "
+                             "extra rules directories specified with -r. "
+                             "There is no need to specify this if no -r flags "
+                             "are used."
                         % default_rulesdir)
     parser.add_argument('-t', dest='tags', action='append', default=[],
-                        help="only check rules whose id/tags match these values")
+                        help="Only check rules whose id/tags match these "
+                             "values.")
     parser.add_argument('-T', dest='listtags', action='store_true',
-                        help="list all the tags")
+                        help="List all the tags.")
     parser.add_argument('-v', dest='verbosity', action='count',
-                        help="Increase verbosity level",
+                        help="Increase verbosity level.",
                         default=0)
     parser.add_argument('-x', dest='skip_list', default=[], action='append',
-                        help="only check rules whose id/tags do not " +
-                        "match these values")
+                        help="Only check rules whose id/tags do not "
+                             "match these values.")
     parser.add_argument('--nocolor', '--nocolour', dest='colored',
                         default=hasattr(sys.stdout, 'isatty') and sys.stdout.isatty(),
                         action='store_false',
-                        help="disable colored output")
+                        help="Disable colored output.")
     parser.add_argument('--force-color', '--force-colour', dest='colored',
                         action='store_true',
-                        help="Try force colored output (relying on salt's code)")
-    parser.add_argument('--exclude', dest='exclude_paths', action='append',
-                        help='path to directories or files to skip. This option'
-                             ' is repeatable.',
-                        default=[])
+                        help="Try force colored output (relying on salt's "
+                             "code).")
+    parser.add_argument('--exclude', dest='exclude_paths',
+                        action='append', default=[],
+                        help="Path to directories or files to skip. This option "
+                             "is repeatable.")
     parser.add_argument('--json', dest='json', action='store_true', default=False,
-                        help='parse the output as JSON')
-    parser.add_argument('--severity', dest='severity', action='store_true', default=False,
-                        help='add the severity to the standard output')
-    parser.add_argument('-c', help='Specify configuration file to use.  Defaults to ".salt-lint"')
+                        help='Parse the output as JSON.')
+    parser.add_argument('--severity', dest='severity',
+                        action='store_true', default=False,
+                        help='Add the severity to the standard output.')
+    parser.add_argument('-c', help="Specify configuration file to use. "
+                                   "Defaults to \".salt-lint\".")
+    parser.add_argument('state', nargs='*', type=str,
+                        help="Specify one or more states to lint.")
 
     # Parse the arguments
-    (options, parsed_args) = parser.parse_known_args(args if args is not None else sys.argv[1:])
+    options = parser.parse_args(args if args is not None else sys.argv[1:])
 
     stdin_state = None
-    states = set(parsed_args)
+    states = []
     matches = list()
     checked_files = set()
 
@@ -80,7 +87,7 @@ def run(args=None):
         stdin_state = tempfile.NamedTemporaryFile('w', suffix='.sls', delete=False)
         stdin_state.write(sys.stdin.read())
         stdin_state.flush()
-        states.add(stdin_state.name)
+        states.append(stdin_state.name)
 
     # Read, parse and validate the configuration
     options_dict = vars(options)
@@ -90,12 +97,15 @@ def run(args=None):
         print(exc)
         return 2
 
+    # Read the states from the configuration
+    states.extend(config.states)
+
     # Show a help message on the screen
     if not states and not (options.listrules or options.listtags):
         parser.print_help(file=sys.stderr)
         return 1
 
-    # Collect the rules from the configution
+    # Collect the rules from the configuration
     rules = RulesCollection(config)
     for rulesdir in config.rulesdirs:
         rules.extend(RulesCollection.create_from_directory(rulesdir, config))

--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -31,14 +31,14 @@ def run(args=None):
     parser.add_argument('-r', action='append', dest='rulesdir',
                         default=[], type=str,
                         help="specify one or more rules directories using "
-                            "one or more -r arguments. Any -r flags override "
-                            "the default rules in %s, unless -R is also used."
+                             "one or more -r arguments. Any -r flags override "
+                             "the default rules in %s, unless -R is also used."
                         % default_rulesdir)
     parser.add_argument('-R', action='store_true', default=False,
                         dest='use_default_rules',
                         help="Use default rules in %s in addition to any extra "
-                            "rules directories specified with -r. There is "
-                            "no need to specify this if no -r flags are used."
+                             "rules directories specified with -r. There is "
+                             "no need to specify this if no -r flags are used."
                         % default_rulesdir)
     parser.add_argument('-t', dest='tags', action='append', default=[],
                         help="only check rules whose id/tags match these values")
@@ -59,7 +59,7 @@ def run(args=None):
                         help="Try force colored output (relying on salt's code)")
     parser.add_argument('--exclude', dest='exclude_paths', action='append',
                         help='path to directories or files to skip. This option'
-                            ' is repeatable.',
+                             ' is repeatable.',
                         default=[])
     parser.add_argument('--json', dest='json', action='store_true', default=False,
                         help='parse the output as JSON')

--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -4,7 +4,7 @@
 
 from __future__ import print_function
 
-import optparse
+import argparse
 import os
 import sys
 import tempfile
@@ -22,53 +22,53 @@ def run(args=None):
     if sys.version_info[0] < 3:
         sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 
-    parser = optparse.OptionParser("%prog [options] init.sls [state ...]",
-                                   version='{} {}'.format(NAME, VERSION))
+    parser = argparse.ArgumentParser(prog=NAME)
+    parser.add_argument('--version', action='version',
+                        version='{} {}'.format(NAME, VERSION))
 
-    parser.add_option('-L', dest='listrules', default=False,
-                      action='store_true', help="list all the rules")
-    parser.add_option('-r', action='append', dest='rulesdir',
-                      default=[], type='str',
-                      help="specify one or more rules directories using "
-                           "one or more -r arguments. Any -r flags override "
-                           "the default rules in %s, unless -R is also used."
-                      % default_rulesdir)
-    parser.add_option('-R', action='store_true',
-                      default=False,
-                      dest='use_default_rules',
-                      help="Use default rules in %s in addition to any extra "
-                           "rules directories specified with -r. There is "
-                           "no need to specify this if no -r flags are used."
-                      % default_rulesdir)
-    parser.add_option('-t', dest='tags',
-                      action='append',
-                      default=[],
-                      help="only check rules whose id/tags match these values")
-    parser.add_option('-T', dest='listtags', action='store_true',
-                      help="list all the tags")
-    parser.add_option('-v', dest='verbosity', action='count',
-                      help="Increase verbosity level",
-                      default=0)
-    parser.add_option('-x', dest='skip_list', default=[], action='append',
-                      help="only check rules whose id/tags do not " +
-                      "match these values")
-    parser.add_option('--nocolor', '--nocolour', dest='colored',
-                      default=hasattr(sys.stdout, 'isatty') and sys.stdout.isatty(),
-                      action='store_false',
-                      help="disable colored output")
-    parser.add_option('--force-color', '--force-colour', dest='colored',
-                      action='store_true',
-                      help="Try force colored output (relying on salt's code)")
-    parser.add_option('--exclude', dest='exclude_paths', action='append',
-                      help='Path to directories or files to skip. This option'
-                           ' is repeatable.',
-                      default=[])
-    parser.add_option('--json', dest='json', action='store_true', default=False,
-                      help='parse the output as JSON')
-    parser.add_option('--severity', dest='severity', action='store_true', default=False,
-                      help='add the severity to the standard output')
-    parser.add_option('-c', help='Specify configuration file to use.  Defaults to ".salt-lint"')
-    (options, parsed_args) = parser.parse_args(args if args is not None else sys.argv[1:])
+    parser.add_argument('-L', dest='listrules', default=False,
+                        action='store_true', help="list all the rules")
+    parser.add_argument('-r', action='append', dest='rulesdir',
+                        default=[], type=str,
+                        help="specify one or more rules directories using "
+                            "one or more -r arguments. Any -r flags override "
+                            "the default rules in %s, unless -R is also used."
+                        % default_rulesdir)
+    parser.add_argument('-R', action='store_true', default=False,
+                        dest='use_default_rules',
+                        help="Use default rules in %s in addition to any extra "
+                            "rules directories specified with -r. There is "
+                            "no need to specify this if no -r flags are used."
+                        % default_rulesdir)
+    parser.add_argument('-t', dest='tags', action='append', default=[],
+                        help="only check rules whose id/tags match these values")
+    parser.add_argument('-T', dest='listtags', action='store_true',
+                        help="list all the tags")
+    parser.add_argument('-v', dest='verbosity', action='count',
+                        help="Increase verbosity level",
+                        default=0)
+    parser.add_argument('-x', dest='skip_list', default=[], action='append',
+                        help="only check rules whose id/tags do not " +
+                        "match these values")
+    parser.add_argument('--nocolor', '--nocolour', dest='colored',
+                        default=hasattr(sys.stdout, 'isatty') and sys.stdout.isatty(),
+                        action='store_false',
+                        help="disable colored output")
+    parser.add_argument('--force-color', '--force-colour', dest='colored',
+                        action='store_true',
+                        help="Try force colored output (relying on salt's code)")
+    parser.add_argument('--exclude', dest='exclude_paths', action='append',
+                        help='path to directories or files to skip. This option'
+                            ' is repeatable.',
+                        default=[])
+    parser.add_argument('--json', dest='json', action='store_true', default=False,
+                        help='parse the output as JSON')
+    parser.add_argument('--severity', dest='severity', action='store_true', default=False,
+                        help='add the severity to the standard output')
+    parser.add_argument('-c', help='Specify configuration file to use.  Defaults to ".salt-lint"')
+
+    # Parse the arguments
+    (options, parsed_args) = parser.parse_known_args(args if args is not None else sys.argv[1:])
 
     stdin_state = None
     states = set(parsed_args)

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -21,6 +21,8 @@ class SaltLintConfigError(Exception):
 
 class SaltLintConfig(object):
 
+    # pylint: disable=too-many-instance-attributes
+
     def __init__(self, options={}):  # pylint: disable=dangerous-default-value
         self._options = options
         # Configuration file to use, defaults to ".salt-lint".

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -128,6 +128,9 @@ class SaltLintConfig(object):
                 self.rules[str(name)]['ignore'] = pathspec.PathSpec.from_lines(
                     'gitwildmatch', rule['ignore'].splitlines())
 
+        # Parse states.
+        self.states = self._options.get('state')
+
     def is_file_ignored(self, filepath, rule):
         rule = str(rule)
         if rule not in self.rules or 'ignore' not in self.rules[rule]:


### PR DESCRIPTION
Change `optparse` to `argparse`, because `optparse` is [deprecated since Python 2.7](https://docs.python.org/2/library/optparse.html).

Fixes #128.