### PR TITLE
Fix some more pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -60,8 +60,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=dangerous-default-value,
-        deprecated-module,
+disable=deprecated-module,
         duplicate-code,
         invalid-name,
         missing-docstring,

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,507 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=dangerous-default-value,
+        deprecated-module,
+        duplicate-code,
+        invalid-name,
+        missing-docstring,
+        no-self-use,
+        not-callable,
+        useless-object-inheritance,
+        wrong-spelling-in-comment,
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: de_LI (myspell), de_AT
+# (myspell), de_DE (myspell), en_GB (myspell), de_BE (myspell), en_NG
+# (myspell), en_IE (myspell), en_GH (myspell), en_ZM (myspell), en_JM
+# (myspell), en_AU (myspell), en_CA (myspell), en_DK (myspell), en_ZW
+# (myspell), en_NZ (myspell), en_AG (myspell), en_BS (myspell), en_HK
+# (myspell), en_ZA (myspell), en_BZ (myspell), en_TT (myspell), en_BW
+# (myspell), de_LU (myspell), en_MW (myspell), en_SG (myspell), en_US
+# (myspell), en_PH (myspell), en_NA (myspell), en_IN (myspell), de_CH
+# (myspell)..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,SaltLintRule
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=6
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=10
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=20
+
+# Maximum number of locals for function / method body.
+max-locals=20
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=60
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=1
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
     - codespell --version
     - codespell --skip="./.git*"
     - pylint --version
-    - pylint --disable=missing-docstring,invalid-name,no-self-use,useless-object-inheritance,too-many-instance-attributes,too-few-public-methods,too-many-locals,deprecated-module,no-member,not-callable,too-many-statements,too-many-branches,too-many-arguments,duplicate-code,dangerous-default-value $(find . -type f -name "*.py")
+    - pylint --rcfile=.pylintrc $(find . -type f -name "*.py")
 
   - python: 3.8
     before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ jobs:
     - pip install codespell
     - pip install pylint
     script:
+    - flake8 --version
     - flake8
     - codespell --version
     - codespell --skip="./.git*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
     - codespell --version
     - codespell --skip="./.git*"
     - pylint --version
-    - pylint --disable=missing-docstring,invalid-name,unused-argument,no-self-use,useless-object-inheritance,too-many-instance-attributes,too-few-public-methods,too-many-locals,deprecated-module,no-member,not-callable,too-many-statements,too-many-branches,too-many-arguments,duplicate-code,dangerous-default-value $(find . -type f -name "*.py")
+    - pylint --disable=missing-docstring,invalid-name,no-self-use,useless-object-inheritance,too-many-instance-attributes,too-few-public-methods,too-many-locals,deprecated-module,no-member,not-callable,too-many-statements,too-many-branches,too-many-arguments,duplicate-code,dangerous-default-value $(find . -type f -name "*.py")
 
   - python: 3.8
     before_install:

--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -114,9 +114,9 @@ def run(args=None):
     if config.json:
         formatter = formatters.JsonFormatter()
     elif config.severity:
-        formatter = formatters.SeverityFormatter()
+        formatter = formatters.SeverityFormatter(config.colored)
     else:
-        formatter = formatters.Formatter()
+        formatter = formatters.Formatter(config.colored)
 
     for state in states:
         runner = Runner(rules, state, config, checked_files)
@@ -126,7 +126,7 @@ def run(args=None):
     matches.sort(key=lambda x: (x.filename, x.linenumber, x.rule.id))
 
     # Show the matches on the screen
-    formatter.process(matches, config.colored)
+    formatter.process(matches)
 
     # Delete stdin temporary file
     if stdin_state:

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -21,7 +21,7 @@ class SaltLintConfigError(Exception):
 
 class SaltLintConfig(object):
 
-    def __init__(self, options=dict()):
+    def __init__(self, options={}):  # pylint: disable=dangerous-default-value
         self._options = options
         # Configuration file to use, defaults to ".salt-lint".
         config = options.get('c')

--- a/saltlint/formatters/__init__.py
+++ b/saltlint/formatters/__init__.py
@@ -12,15 +12,24 @@ except ImportError:
     import salt.utils as saltcolor
 
 
-class Formatter(object):
+class BaseFormatter(object):
 
-    def process(self, matches, colored=False):
+    def __init__(self, colored=False):
+        self.colored = colored
+
+    def process(self, matches):
         for match in matches:
-            print(self.format(match, colored))
+            print(self.format(match))
 
-    def format(self, match, colored=False):
+    def format(self, match):
+        raise NotImplementedError()
+
+
+class Formatter(BaseFormatter):
+
+    def format(self, match):
         formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"
-        if colored:
+        if self.colored:
             color = saltcolor.get_colors()
             return formatstr.format(
                 u'{0}[{1}]{2}'.format(color['RED'], match.rule.id,
@@ -42,15 +51,12 @@ class Formatter(object):
             match.line)
 
 
-class SeverityFormatter(object):
-    def process(self, matches, colored=False):
-        for match in matches:
-            print(self.format(match, colored))
+class SeverityFormatter(BaseFormatter):
 
-    def format(self, match, colored=False):
+    def format(self, match):
         formatstr = u"{0} {sev} {1}\n{2}:{3}\n{4}\n"
 
-        if colored:
+        if self.colored:
             color = saltcolor.get_colors()
             return formatstr.format(
                 u'{0}[{1}]{2}'.format(color['RED'], match.rule.id,
@@ -75,7 +81,7 @@ class SeverityFormatter(object):
             sev=u'[{0}]'.format(match.rule.severity))
 
 
-class JsonFormatter(object):
+class JsonFormatter(BaseFormatter):
 
     def process(self, matches):
         items = []

--- a/saltlint/formatters/__init__.py
+++ b/saltlint/formatters/__init__.py
@@ -77,7 +77,7 @@ class SeverityFormatter(object):
 
 class JsonFormatter(object):
 
-    def process(self, matches, *args, **kwargs):
+    def process(self, matches):
         items = []
         for match in matches:
             items.append(self.format(match))

--- a/saltlint/linter.py
+++ b/saltlint/linter.py
@@ -92,7 +92,8 @@ class RulesCollection(object):
     def extend(self, more):
         self.rules.extend(more)
 
-    def run(self, statefile, tags=set(), skip_list=frozenset()):
+    # pylint: disable=dangerous-default-value
+    def run(self, statefile, tags=[], skip_list=frozenset()):
         text = ""
         matches = list()
 

--- a/saltlint/rules/FileExtensionRule.py
+++ b/saltlint/rules/FileExtensionRule.py
@@ -16,7 +16,7 @@ class FileExtensionRule(SaltLintRule):
     done = []  # already noticed path list
     version_added = 'v0.0.1'
 
-    def match(self, file, line):
+    def match(self, file, _):
         if file['type'] != 'state':
             return False
 

--- a/saltlint/rules/FileModeLeadingZeroRule.py
+++ b/saltlint/rules/FileModeLeadingZeroRule.py
@@ -17,5 +17,5 @@ class FileModeLeadingZeroRule(SaltLintRule):
 
     bracket_regex = re.compile(r"^\s+- ((dir_)|(file_))?mode: ((')|(\"))?[0-9]{3}([\D]|$)")
 
-    def match(self, file, line):
+    def match(self, _, line):
         return self.bracket_regex.search(line)

--- a/saltlint/rules/FileModeQuotationRule.py
+++ b/saltlint/rules/FileModeQuotationRule.py
@@ -17,5 +17,5 @@ class FileModeQuotationRule(SaltLintRule):
 
     bracket_regex = re.compile(r"^\s+- ((dir_)|(file_))?mode: [0-9]{3,4}")
 
-    def match(self, file, line):
+    def match(self, _, line):
         return self.bracket_regex.search(line)

--- a/saltlint/rules/JinjaCommentHasSpacesRule.py
+++ b/saltlint/rules/JinjaCommentHasSpacesRule.py
@@ -17,5 +17,5 @@ class JinjaCommentHasSpacesRule(SaltLintRule):
 
     bracket_regex = re.compile(r"{#[^ \-\+]|{#[\-\+][^ ]|[^ \-\+]#}|[^ ][\-\+]#}")
 
-    def match(self, file, line):
+    def match(self, _, line):
         return self.bracket_regex.search(line)

--- a/saltlint/rules/JinjaPillarGrainsGetFormatRule.py
+++ b/saltlint/rules/JinjaPillarGrainsGetFormatRule.py
@@ -18,5 +18,5 @@ class JinjaPillarGrainsGetFormatRule(SaltLintRule):
 
     bracket_regex = re.compile(r"{{( |\-|\+)?.(pillar|grains).get\(.+}}")
 
-    def match(self, file, line):
+    def match(self, _, line):
         return self.bracket_regex.search(line)

--- a/saltlint/rules/JinjaStatementHasSpacesRule.py
+++ b/saltlint/rules/JinjaStatementHasSpacesRule.py
@@ -17,5 +17,5 @@ class JinjaStatementHasSpacesRule(SaltLintRule):
 
     bracket_regex = re.compile(r"{%[^ \-\+]|{%[\-\+][^ ]|[^ \-\+]%}|[^ ][\-\+]%}")
 
-    def match(self, file, line):
+    def match(self, _, line):
         return self.bracket_regex.search(line)

--- a/saltlint/rules/JinjaVariableHasSpacesRule.py
+++ b/saltlint/rules/JinjaVariableHasSpacesRule.py
@@ -17,5 +17,5 @@ class JinjaVariableHasSpacesRule(SaltLintRule):
 
     bracket_regex = re.compile(r"{{[^ \-\+]|{{[-\+][^ ]|[^ \-\+]}}|[^ ][-\+]}}")
 
-    def match(self, file, line):
+    def match(self, _, line):
         return self.bracket_regex.search(line)

--- a/saltlint/rules/LineTooLongRule.py
+++ b/saltlint/rules/LineTooLongRule.py
@@ -17,5 +17,5 @@ class LineTooLongRule(SaltLintRule):
     tags = ['formatting']
     version_added = 'v0.0.1'
 
-    def match(self, file, line):
+    def match(self, _, line):
         return len(line) > 160

--- a/saltlint/rules/NoIrregularSpacesRule.py
+++ b/saltlint/rules/NoIrregularSpacesRule.py
@@ -38,6 +38,6 @@ class NoIrregularSpacesRule(SaltLintRule):
         u"\u3000",  # Ideographic Space
         ]
 
-    def match(self, file, line):
+    def match(self, _, line):
         res = [i for i in self.irregular_spaces if i in line]
         return len(res) != 0

--- a/saltlint/rules/NoTabsRule.py
+++ b/saltlint/rules/NoTabsRule.py
@@ -14,5 +14,5 @@ class NoTabsRule(SaltLintRule):
     tags = ['formatting']
     version_added = 'v0.0.1'
 
-    def match(self, file, line):
+    def match(self, _, line):
         return '\t' in line

--- a/saltlint/rules/TrailingWhitespaceRule.py
+++ b/saltlint/rules/TrailingWhitespaceRule.py
@@ -13,6 +13,6 @@ class TrailingWhitespaceRule(SaltLintRule):
     tags = ['formatting']
     version_added = 'v0.0.1'
 
-    def match(self, file, line):
+    def match(self, _, line):
         line = line.replace("\r", "")
         return line.rstrip() != line

--- a/saltlint/rules/YamlHasOctalValueRule.py
+++ b/saltlint/rules/YamlHasOctalValueRule.py
@@ -17,5 +17,5 @@ class YamlHasOctalValueRule(SaltLintRule):
 
     bracket_regex = re.compile(r"(?<=:)\s{0,}0[0-9]{1,}\s{0,}((?={#)|(?=#)|(?=$))")
 
-    def match(self, file, line):
+    def match(self, _, line):
         return self.bracket_regex.search(line)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,7 +9,7 @@ from saltlint.config import SaltLintConfig
 
 
 class RunFromText(object):
-    """Use Runner on temporary files created from unittest text snippets."""
+    """Use Runner on temporary files created from unit-test text snippets."""
 
     def __init__(self, collection):
         self.collection = collection


### PR DESCRIPTION
Hi @roaldnefs,

I fixed here 2 pylint issues: **unused-argument**, and **dangerous-default-value**.

This also move the configuration to a separated .pylintrc file, so that the configuration has much more flexibility. Let me know if you agree with that. 

Pylint wants normally the snake_case instead of the CamelCase you are using here. Do we want to stay with this style?