### PR TITLE
Fix configuration test after introducing pathspec

### DIFF
--- a/tests/unit/TestConfig.py
+++ b/tests/unit/TestConfig.py
@@ -53,7 +53,7 @@ class TestConfig(unittest.TestCase):
         self.assertNotIn('200', self.config.skip_list)
 
         # Check 'exclude_paths'
-        self.assertIn('exclude_this_file', self.config.exclude_paths)
+        self.assertTrue(self.config.exclude_paths.match_file('exclude_this_file'))
         self.assertEqual(3, len(self.config.exclude_paths))
 
     def test_is_file_ignored(self):


### PR DESCRIPTION
Fix configuration test after introducing pathspec in #126. It is causing the unit tests on the `develop` branch to break.