### PR TITLE
Fix rule 211

### DIFF
--- a/saltlint/rules/JinjaPillarGrainsGetFormatRule.py
+++ b/saltlint/rules/JinjaPillarGrainsGetFormatRule.py
@@ -10,13 +10,14 @@ from saltlint.linter import SaltLintRule
 class JinjaPillarGrainsGetFormatRule(SaltLintRule):
     id = '211'
     shortdesc = 'pillar.get or grains.get should be formatted differently'
-    description = "pillar.get and grains.get should always be formatted" \
-                  " like salt['pillar.get']('item') or grains['item1']"
+    description = "pillar.get and grains.get should always be formatted " \
+                  "like salt['pillar.get']('item'), grains['item1'] or " \
+                  " pillar.get('item')"
     severity = 'HIGH'
     tags = ['formatting', 'jinja']
     version_added = 'v0.0.10'
 
-    bracket_regex = re.compile(r"{{( |\-|\+)?.(pillar|grains).get\(.+}}")
+    bracket_regex = re.compile(r"{{( |\-|\+)?.(pillar|grains).get\[.+}}")
 
     def match(self, _, line):
         return self.bracket_regex.search(line)

--- a/tests/unit/TestJinjaPillarGrainsGetFormatRule.py
+++ b/tests/unit/TestJinjaPillarGrainsGetFormatRule.py
@@ -11,25 +11,31 @@ from tests import RunFromText
 
 
 GOOD_STATEMENT_LINE = '''
-example_test:
+example_file:
   file.managed:
-    - name: /etc/test
-    - user: root
-    - group: {{ salt['pillar.get']('item') }} test
-    - something: {{ grains['item'] }}
-    - content: |
-        {{ salt['pillar.get']('test') }}
+    - name: /tmp/good.txt
+    - contents: |
+        {{ salt['pillar.get']('item') }}
+        {{ pillar.get('item') }}
+        {{ pillar['item'] }}
+        {{ salt['grains.get']('saltversion') }}
+        {{ grains.get('saltversion') }}
+        {{ grains['saltversion'] }}
 '''
 
 BAD_STATEMENT_LINE = '''
-example_test:
+example_file:
   file.managed:
-    - name: /etc/test
-    - user: root
-    - group: {{ pillar.get('item') }} test
-    - something: {{ grains.get('item')}}
-    - content: |
-        {{ salt['pillar.get']('test') }}
+    - name: /tmp/bad.txt
+    - contents: |
+        {{ salt['pillar.get']('item') }}
+        {{ pillar.get('item') }}
+        {{ pillar['item'] }}
+        {{ pillar.get['item'] }} # this line is broken
+        {{ salt['grains.get']('saltversion') }}
+        {{ grains.get('saltversion') }}
+        {{ grains['saltversion'] }}
+        {{ grains.get['saltversion'] }} # this line is broken
 '''
 
 class TestJinjaPillarGrainsGetFormatRule(unittest.TestCase):


### PR DESCRIPTION
Fix rule `211`. The rule should have spotted the usage of `pillar.get['key']` or `grains.get['key']`. All example on the [wiki](https://github.com/warpnet/salt-lint/wiki/211) are actually correct examples and will be rendered in Jinja without any problems.

Using `pillar.get['key']` in a SLS file results in:

```
local:
    Data failed to compile:
----------
    Rendering SLS 'base:example' failed: Jinja variable 'method object' has no attribute ‘key'
```

Using `grains.get['key']` results in:
```
local:
    Data failed to compile:
----------
    Rendering SLS 'base:example' failed: Jinja variable 'builtin_function_or_method object' has no attribute 'key'
```

Fixes #140 