### PR TITLE
Version 0.2.1 Release

### DIFF
--- a/saltlint/__init__.py
+++ b/saltlint/__init__.py
@@ -5,7 +5,7 @@
 """
 
 NAME = 'salt-lint'
-VERSION = '0.2.0'
+VERSION = '0.2.1'
 DESCRIPTION = __doc__
 
 __author__ = 'Warpnet B.V.'

--- a/saltlint/rules/JinjaPillarGrainsGetFormatRule.py
+++ b/saltlint/rules/JinjaPillarGrainsGetFormatRule.py
@@ -10,13 +10,14 @@ import re
 class JinjaPillarGrainsGetFormatRule(SaltLintRule):
     id = '211'
     shortdesc = 'pillar.get or grains.get should be formatted differently'
-    description = "pillar.get and grains.get should always be formatted" \
-                  " like salt['pillar.get']('item') or grains['item1']"
+    description = "pillar.get and grains.get should always be formatted " \
+                  "like salt['pillar.get']('item'), grains['item1'] or " \
+                  " pillar.get('item')"
     severity = 'HIGH'
     tags = ['formatting', 'jinja']
     version_added = 'v0.0.10'
 
-    bracket_regex = re.compile(r"{{( |\-|\+)?.(pillar|grains).get\(.+}}")
+    bracket_regex = re.compile(r"{{( |\-|\+)?.(pillar|grains).get\[.+}}")
 
     def match(self, file, line):
         return self.bracket_regex.search(line)

--- a/tests/unit/TestJinjaPillarGrainsGetFormatRule.py
+++ b/tests/unit/TestJinjaPillarGrainsGetFormatRule.py
@@ -11,25 +11,31 @@ from tests import RunFromText
 
 
 GOOD_STATEMENT_LINE = '''
-example_test:
+example_file:
   file.managed:
-    - name: /etc/test
-    - user: root
-    - group: {{ salt['pillar.get']('item') }} test
-    - something: {{ grains['item'] }}
-    - content: |
-        {{ salt['pillar.get']('test') }}
+    - name: /tmp/good.txt
+    - contents: |
+        {{ salt['pillar.get']('item') }}
+        {{ pillar.get('item') }}
+        {{ pillar['item'] }}
+        {{ salt['grains.get']('saltversion') }}
+        {{ grains.get('saltversion') }}
+        {{ grains['saltversion'] }}
 '''
 
 BAD_STATEMENT_LINE = '''
-example_test:
+example_file:
   file.managed:
-    - name: /etc/test
-    - user: root
-    - group: {{ pillar.get('item') }} test
-    - something: {{ grains.get('item')}}
-    - content: |
-        {{ salt['pillar.get']('test') }}
+    - name: /tmp/bad.txt
+    - contents: |
+        {{ salt['pillar.get']('item') }}
+        {{ pillar.get('item') }}
+        {{ pillar['item'] }}
+        {{ pillar.get['item'] }} # this line is broken
+        {{ salt['grains.get']('saltversion') }}
+        {{ grains.get('saltversion') }}
+        {{ grains['saltversion'] }}
+        {{ grains.get['saltversion'] }} # this line is broken
 '''
 
 class TestJinjaPillarGrainsGetFormatRule(unittest.TestCase):


### PR DESCRIPTION
### Introduction

Version `v0.2.1` release, requires to be tagged after being merged into `master` and  the [wiki](https://github.com/warpnet/salt-lint/wiki/211) needs to be updated.

### Fixed

- Fix rule 211 (#142, cherry picked from `develop`).

### Other

Fixes #140.