### PR TITLE
Bump version to v0.2.2

### DIFF
--- a/saltlint/__init__.py
+++ b/saltlint/__init__.py
@@ -5,7 +5,7 @@
 """
 
 NAME = 'salt-lint'
-VERSION = '0.2.1'
+VERSION = '0.2.2'
 DESCRIPTION = __doc__
 
 __author__ = 'Warpnet B.V.'


### PR DESCRIPTION
Bump version to `v0.2.2`.

Releasing the 0.2.2 version also fixes #145.