### PR TITLE
Remove Salt as a dependency

### DIFF
--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -5,9 +5,7 @@ import os
 import sys
 import yaml
 import pathspec
-
-# Import Salt libs
-from salt.ext import six
+import six
 
 import saltlint.utils
 

--- a/saltlint/formatters/__init__.py
+++ b/saltlint/formatters/__init__.py
@@ -5,11 +5,36 @@
 
 import json
 
-# Import salt libs
-try:
-    import salt.utils.color as saltcolor
-except ImportError:
-    import salt.utils as saltcolor
+
+def get_colors(use=True):
+    """
+    Return the colors as a dict, pass False to return the colors as empty
+    strings.
+    """
+    colors = {
+        "BLACK": "\033[0;30m", # black
+        "DARK_GRAY": "\033[1;30m", # bold, black
+        "RED": "\033[0;31m",# red
+        "LIGHT_RED": "\033[1;31m" , # bold, red
+        "GREEN": "\033[0;32m", # green
+        "LIGHT_GREEN": "\033[1;32m", # bold, green
+        "BLUE": "\033[0;34m", # blue
+        "LIGHT_BLUE": "\033[1;34m", # bold, blue
+        "MAGENTA": "\033[0;35m", # magenta,
+        "LIGHT_MAGENTA": "\033[1;35m", # bold, magenta
+        "CYAN": "\033[0;36m", # cyan
+        "LIGHT_CYAN": "\033[1;36m", # bold, cyan
+        "LIGHT_GRAY": "\033[0;37m", # white
+        "WHITE": "\033[1;37m", # bold, white
+        "DEFAULT_COLOR": "\033[00m", # default
+        "ENDC": "\033[0m", # reset
+    }
+
+    if not use:
+        for color in colors:
+            colors[color] = ''
+
+    return colors
 
 
 class BaseFormatter(object):
@@ -29,26 +54,19 @@ class Formatter(BaseFormatter):
 
     def format(self, match):
         formatstr = u"{0} {1}\n{2}:{3}\n{4}\n"
-        if self.colored:
-            color = saltcolor.get_colors()
-            return formatstr.format(
-                u'{0}[{1}]{2}'.format(color['RED'], match.rule.id,
-                                      color['ENDC']),
-                u'{0}{1}{2}'.format(color['LIGHT_RED'], match.message,
-                                    color['ENDC']),
-                u'{0}{1}{2}'.format(color['BLUE'], match.filename,
-                                    color['ENDC']),
-                u'{0}{1}{2}'.format(color['CYAN'], str(match.linenumber),
-                                    color['ENDC']),
-                u'{0}{1}{2}'.format(color['MAGENTA'], match.line, color['ENDC'])
-            )
 
+        color = get_colors(self.colored)
         return formatstr.format(
-            u'[{0}]'.format(match.rule.id),
-            match.message,
-            match.filename,
-            match.linenumber,
-            match.line)
+            u'{0}[{1}]{2}'.format(color['RED'], match.rule.id,
+                                  color['ENDC']),
+            u'{0}{1}{2}'.format(color['LIGHT_RED'], match.message,
+                                color['ENDC']),
+            u'{0}{1}{2}'.format(color['BLUE'], match.filename,
+                                color['ENDC']),
+            u'{0}{1}{2}'.format(color['CYAN'], str(match.linenumber),
+                                color['ENDC']),
+            u'{0}{1}{2}'.format(color['MAGENTA'], match.line, color['ENDC'])
+        )
 
 
 class SeverityFormatter(BaseFormatter):
@@ -56,29 +74,20 @@ class SeverityFormatter(BaseFormatter):
     def format(self, match):
         formatstr = u"{0} {sev} {1}\n{2}:{3}\n{4}\n"
 
-        if self.colored:
-            color = saltcolor.get_colors()
-            return formatstr.format(
-                u'{0}[{1}]{2}'.format(color['RED'], match.rule.id,
-                                      color['ENDC']),
-                u'{0}{1}{2}'.format(color['LIGHT_RED'], match.message,
-                                    color['ENDC']),
-                u'{0}{1}{2}'.format(color['BLUE'], match.filename,
-                                    color['ENDC']),
-                u'{0}{1}{2}'.format(color['CYAN'], str(match.linenumber),
-                                    color['ENDC']),
-                u'{0}{1}{2}'.format(color['MAGENTA'], match.line, color['ENDC']),
-                sev=u'{0}[{1}]{2}'.format(color['RED'], match.rule.severity,
-                                          color['ENDC'])
-            )
-
+        color = get_colors(self.colored)
         return formatstr.format(
-            u'[{0}]'.format(match.rule.id),
-            match.message,
-            match.filename,
-            match.linenumber,
-            match.line,
-            sev=u'[{0}]'.format(match.rule.severity))
+            u'{0}[{1}]{2}'.format(color['RED'], match.rule.id,
+                                  color['ENDC']),
+            u'{0}{1}{2}'.format(color['LIGHT_RED'], match.message,
+                                color['ENDC']),
+            u'{0}{1}{2}'.format(color['BLUE'], match.filename,
+                                color['ENDC']),
+            u'{0}{1}{2}'.format(color['CYAN'], str(match.linenumber),
+                                color['ENDC']),
+            u'{0}{1}{2}'.format(color['MAGENTA'], match.line, color['ENDC']),
+            sev=u'{0}[{1}]{2}'.format(color['RED'], match.rule.severity,
+                                      color['ENDC'])
+        )
 
 
 class JsonFormatter(BaseFormatter):

--- a/saltlint/linter.py
+++ b/saltlint/linter.py
@@ -9,9 +9,7 @@ import os
 import re
 import sys
 import codecs
-
-# import Salt libs
-from salt.ext import six
+import six
 
 import saltlint.utils
 from saltlint.config import SaltLintConfig

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     },
     include_package_data=True,
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    install_requires=['salt', 'pathspec>=0.6.0'],
+    install_requires=['six', 'pyyaml', 'pathspec>=0.6.0'],
     license=__license__,
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Remove Salt as a dependency of salt-lint by:
- including the `six` and `pyyaml` libraries directly.
- specifying the colors directly.

This also fixes #135.