### PR TITLE
Fix Dockerfile for salt-lint for version 0.3.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,11 @@
 FROM python:3.7-alpine
 LABEL maintainer="info@warpnet.nl"
 
-# Install required alpine packages
-# hadolint ignore=DL3018,DL3019
-RUN apk add --no-cache gcc g++ build-base libzmq musl-dev zeromq-dev
-
 # Install the salt-lint package
-RUN pip install --no-cache salt-lint==v0.2.0
+# hadolint ignore=DL3013
+RUN pip install --no-cache salt-lint
 
-# Remove development utilities
-RUN apk del --no-cache gcc g++ build-base libzmq musl-dev zeromq-dev \
- && rm -rf /var/cache/apk/*
-
+# Create the linter user
 RUN addgroup -S -g 800 linter \
  && adduser -S -u 800 -S -H -D -G linter linter
 


### PR DESCRIPTION
Fix Dockerfile for salt-lint for version 0.3.0 by removing the version
pinning and only install salt-lint itself as SaltStack has been removed
as dependency.
