### PR TITLE
Automate PyPi release using GitHub Actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,5 +1,9 @@
 name: Build and publish salt-lint to PyPi
-on: push
+on:
+  push:
+    branches:
+    - master
+
 jobs:
   build-n-publish:
     name: Build and publish salt-lint to PyPi

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,9 +10,15 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Install wheel
+      run: >-
+        python -m
+        pip install
+        wheel
+        --user
     - name: Build salt-lint
       run: >-
-        python setup.py sdist bdist_wheel
+        pythonsetup.py sdist bdist_wheel
     - name: Publish salt-lint to Test PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -18,7 +18,7 @@ jobs:
         --user
     - name: Build salt-lint
       run: >-
-        pythonsetup.py sdist bdist_wheel
+        python setup.py sdist bdist_wheel
     - name: Publish salt-lint to Test PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,25 @@
+name: Build and publish salt-lint to PyPi
+on: push
+jobs:
+  build-n-publish:
+    name: Build and publish salt-lint to PyPi
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Build salt-lint
+      run: >-
+        python setup.py sdist bdist_wheel
+    - name: Publish salt-lint to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish salt-lint to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Automatically build and publish salt-lint to PyPi using GitHub Actions.

Fixes #122 