### PR TITLE
Only publish build on tags to prevent duplicate releases

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,6 +24,7 @@ jobs:
       run: >-
         python setup.py sdist bdist_wheel
     - name: Publish salt-lint to Test PyPI
+      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.test_pypi_password }}


### PR DESCRIPTION
Only publish build on tags to prevent duplicate releases.