### PR TITLE
Fix GitHub Actions automated release to PyPi

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,35 @@
+name: Build and publish salt-lint to PyPi
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build-n-publish:
+    name: Build and publish salt-lint to PyPi
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install wheel
+      run: >-
+        python -m
+        pip install
+        wheel
+        --user
+    - name: Build salt-lint
+      run: >-
+        python setup.py sdist bdist_wheel
+    - name: Publish salt-lint to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish salt-lint to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,6 +24,7 @@ jobs:
       run: >-
         python setup.py sdist bdist_wheel
     - name: Publish salt-lint to Test PyPI
+      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.test_pypi_password }}


### PR DESCRIPTION
Fix GitHub Actions to only release to PyPi on tagged commits in the master branch.