### PR TITLE
Replace optparse by argparse

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,6 +75,6 @@ jobs:
         pylint --ignore=build \
         --disable=missing-docstring,invalid-name,unused-argument,\
         no-self-use,useless-object-inheritance,too-many-instance-attributes,\
-        too-few-public-methods,too-many-locals,deprecated-module,no-member,\
-        not-callable,too-many-statements,too-many-branches,too-many-arguments,\
+        too-few-public-methods,too-many-locals,no-member,not-callable,\
+        too-many-statements,too-many-branches,too-many-arguments,\
         duplicate-code,dangerous-default-value $(find . -type f -name "*.py")

--- a/README.md
+++ b/README.md
@@ -33,34 +33,33 @@ pip install git+https://github.com/warpnet/salt-lint.git
 The following is the output from `salt-lint --help`, providing an overview of the basic command line options:
 
 ```bash
-Usage: salt-lint [options] init.sls [state ...]
+usage: salt-lint [-h] [-L] [-r RULESDIR] [-R] [-t TAGS] [-T] [-v] [-x SKIP_LIST] [--nocolor] [--force-color]
+                 [--exclude EXCLUDE_PATHS] [--json] [--severity] [-c C]
+                 files [files ...]
 
-Options:
-  --version             show program's version number and exit
+positional arguments:
+  files                 One or more files or paths.
+
+optional arguments:
   -h, --help            show this help message and exit
   -L                    list all the rules
-  -r RULESDIR           specify one or more rules directories using one or
-                        more -r arguments. Any -r flags override the default
-                        rules in /path/to/salt-lint/saltlint/rules, unless
-                        -R is also used.
-  -R                    Use default rules in
-                        /path/to/salt-lint/saltlint/rules in addition to any
-                        extra rules directories specified with -r. There is
-                        no need to specify this if no -r flags are used.
+  -r RULESDIR           specify one or more rules directories using one or more -r arguments. Any -r flags
+                        override the default rules in /path/to/salt-lint/saltlint/rules, unless -R is also used.
+  -R                    Use default rules in /path/to/salt-lint/saltlint/rules in addition to any extra rules
+                        directories specified with -r. There is no need to specify this if no -r flags are used.
   -t TAGS               only check rules whose id/tags match these values
   -T                    list all the tags
   -v                    Increase verbosity level
-  -x SKIP_LIST          only check rules whose id/tags do not match these
-                        values
-  --nocolor             disable colored output
-  --force-color         Try force colored output (relying on salt's code)
-  --exclude=EXCLUDE_PATHS
-                        path to directories or files to skip. This option is
-                        repeatable.
+  -x SKIP_LIST          only check rules whose id/tags do not match these values
+  --nocolor, --nocolour
+                        disable colored output
+  --force-color, --force-colour
+                        Try force colored output (relying on salt's code)
+  --exclude EXCLUDE_PATHS
+                        path to directories or files to skip. This option is repeatable.
   --json                parse the output as JSON
   --severity            add the severity to the standard output
-  -c C                  Specify configuration file to use.  Defaults to
-                        ".salt-lint"
+  -c C                  Specify configuration file to use. Defaults to ".salt-lint"
 ```
 
 ## Linting Salt State files

--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -4,7 +4,7 @@
 
 from __future__ import print_function
 
-import optparse
+import argparse
 import os
 import sys
 import tempfile
@@ -22,56 +22,57 @@ def run(args=None):
     if sys.version_info[0] < 3:
         sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 
-    parser = optparse.OptionParser("%prog [options] init.sls [state ...]",
-                                   version='{} {}'.format(NAME, VERSION))
+    parser = argparse.ArgumentParser()
 
-    parser.add_option('-L', dest='listrules', default=False,
-                      action='store_true', help="list all the rules")
-    parser.add_option('-r', action='append', dest='rulesdir',
-                      default=[], type='str',
-                      help="specify one or more rules directories using "
-                           "one or more -r arguments. Any -r flags override "
-                           "the default rules in %s, unless -R is also used."
-                      % default_rulesdir)
-    parser.add_option('-R', action='store_true',
-                      default=False,
-                      dest='use_default_rules',
-                      help="Use default rules in %s in addition to any extra "
-                           "rules directories specified with -r. There is "
-                           "no need to specify this if no -r flags are used."
-                      % default_rulesdir)
-    parser.add_option('-t', dest='tags',
-                      action='append',
-                      default=[],
-                      help="only check rules whose id/tags match these values")
-    parser.add_option('-T', dest='listtags', action='store_true',
-                      help="list all the tags")
-    parser.add_option('-v', dest='verbosity', action='count',
-                      help="Increase verbosity level",
-                      default=0)
-    parser.add_option('-x', dest='skip_list', default=[], action='append',
-                      help="only check rules whose id/tags do not " +
-                      "match these values")
-    parser.add_option('--nocolor', '--nocolour', dest='colored',
-                      default=hasattr(sys.stdout, 'isatty') and sys.stdout.isatty(),
-                      action='store_false',
-                      help="disable colored output")
-    parser.add_option('--force-color', '--force-colour', dest='colored',
-                      action='store_true',
-                      help="Try force colored output (relying on salt's code)")
-    parser.add_option('--exclude', dest='exclude_paths', action='append',
-                      help='path to directories or files to skip. This option'
-                           ' is repeatable.',
-                      default=[])
-    parser.add_option('--json', dest='json', action='store_true', default=False,
-                      help='parse the output as JSON')
-    parser.add_option('--severity', dest='severity', action='store_true', default=False,
-                      help='add the severity to the standard output')
-    parser.add_option('-c', help='Specify configuration file to use.  Defaults to ".salt-lint"')
-    (options, parsed_args) = parser.parse_args(args if args is not None else sys.argv[1:])
+    parser.add_argument('-L', dest='listrules', default=False,
+                        action='store_true', help="list all the rules")
+    parser.add_argument('-r', action='append', dest='rulesdir',
+                        default=[],
+                        help="specify one or more rules directories using "
+                             "one or more -r arguments. Any -r flags override "
+                             "the default rules in %s, unless -R is also used."
+                        % default_rulesdir)
+    parser.add_argument('-R', action='store_true',
+                        default=False,
+                        dest='use_default_rules',
+                        help="Use default rules in %s in addition to any extra "
+                             "rules directories specified with -r. There is "
+                             "no need to specify this if no -r flags are used."
+                        % default_rulesdir)
+    parser.add_argument('-t', dest='tags',
+                        action='append',
+                        default=[],
+                        help="only check rules whose id/tags match these values")
+    parser.add_argument('-T', dest='listtags', action='store_true',
+                        help="list all the tags")
+    parser.add_argument('-v', dest='verbosity', action='count',
+                        help="Increase verbosity level",
+                        default=0)
+    parser.add_argument('-x', dest='skip_list', default=[], action='append',
+                        help="only check rules whose id/tags do not " +
+                        "match these values")
+    parser.add_argument('--nocolor', '--nocolour', dest='colored',
+                        default=hasattr(sys.stdout, 'isatty') and sys.stdout.isatty(),
+                        action='store_false',
+                        help="disable colored output")
+    parser.add_argument('--force-color', '--force-colour', dest='colored',
+                        action='store_true',
+                        help="Try force colored output (relying on salt's code)")
+    parser.add_argument('--exclude', dest='exclude_paths', action='append',
+                        help='path to directories or files to skip. This option'
+                             ' is repeatable.',
+                        default=[])
+    parser.add_argument('--json', dest='json', action='store_true', default=False,
+                        help='parse the output as JSON')
+    parser.add_argument('--severity', dest='severity', action='store_true', default=False,
+                        help='add the severity to the standard output')
+    parser.add_argument('-c', help='Specify configuration file to use.  Defaults to ".salt-lint"')
+    parser.add_argument(dest='files', nargs='+', help='One or more files or paths.')
+
+    options = parser.parse_args(args if args is not None else sys.argv[1:])
 
     stdin_state = None
-    states = set(parsed_args)
+    states = set(options.files)
     matches = []
     checked_files = set()
 
@@ -95,7 +96,7 @@ def run(args=None):
         parser.print_help(file=sys.stderr)
         return 1
 
-    # Collect the rules from the configution
+    # Collect the rules from the configuration
     rules = RulesCollection(config)
     for rulesdir in config.rulesdirs:
         rules.extend(RulesCollection.create_from_directory(rulesdir, config))

--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 import codecs
 
-from saltlint import formatters, NAME, VERSION
+from saltlint import formatters
 from saltlint.config import SaltLintConfig, SaltLintConfigError, default_rulesdir
 from saltlint.linter import RulesCollection, Runner
 


### PR DESCRIPTION
Replace `optparse` by `argparse` and update `README.md` to show the new usage information.

The arguments are backwards compatible with the previous version of `salt-lint`.

Fixes #128 