### PR TITLE
Add --version flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install git+https://github.com/warpnet/salt-lint.git
 The following is the output from `salt-lint --help`, providing an overview of the basic command line options:
 
 ```bash
-usage: salt-lint [-h] [-L] [-r RULESDIR] [-R] [-t TAGS] [-T] [-v] [-x SKIP_LIST] [--nocolor] [--force-color]
+usage: salt-lint [-h] [--version] [-L] [-r RULESDIR] [-R] [-t TAGS] [-T] [-v] [-x SKIP_LIST] [--nocolor] [--force-color]
                  [--exclude EXCLUDE_PATHS] [--json] [--severity] [-c C]
                  files [files ...]
 
@@ -42,6 +42,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --version             show program's version number and exit
   -L                    list all the rules
   -r RULESDIR           specify one or more rules directories using one or more -r arguments. Any -r flags
                         override the default rules in /path/to/salt-lint/saltlint/rules, unless -R is also used.

--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import codecs
 
+from saltlint import NAME, VERSION
 from saltlint import formatters
 from saltlint.config import SaltLintConfig, SaltLintConfigError, default_rulesdir
 from saltlint.linter import RulesCollection, Runner
@@ -22,8 +23,9 @@ def run(args=None):
     if sys.version_info[0] < 3:
         sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prog=NAME)
 
+    parser.add_argument('--version', action='version', version='%(prog)s {}'.format(VERSION))
     parser.add_argument('-L', dest='listrules', default=False,
                         action='store_true', help="list all the rules")
     parser.add_argument('-r', action='append', dest='rulesdir',


### PR DESCRIPTION
Add `--version` flag to the command line interface of salt-lint.

Closes #185