### PR TITLE
Rename master branch to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ main, develop ]
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: lint
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ main, develop ]
 
 jobs:
   markdown:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,7 +2,7 @@ name: Build and publish salt-lint to PyPi
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - v*
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![PyPI](https://img.shields.io/pypi/v/salt-lint.svg)](https://pypi.org/project/salt-lint)
-![GitHub Actions: test](https://github.com/warpnet/salt-lint/workflows/build/badge.svg?branch=master)
-![GitHub Actions: lint](https://github.com/warpnet/salt-lint/workflows/lint/badge.svg?branch=master)
+![GitHub Actions: test](https://github.com/warpnet/salt-lint/workflows/build/badge.svg?branch=main)
+![GitHub Actions: lint](https://github.com/warpnet/salt-lint/workflows/lint/badge.svg?branch=main)
 
 # Salt-lint
 


### PR DESCRIPTION
Rename the `master` branch to `main`.

Fixes #186