### PR TITLE
Fix pylint errors by using raise from statement

### DIFF
--- a/saltlint/__main__.py
+++ b/saltlint/__main__.py
@@ -14,5 +14,5 @@ if __name__ == "__main__":
     except IOError as exc:
         if exc.errno != errno.EPIPE:
             raise
-    except RuntimeError as e:
-        raise SystemExit(str(e))
+    except RuntimeError as exc:
+        raise SystemExit(str(exc)) from exc

--- a/saltlint/__main__.py
+++ b/saltlint/__main__.py
@@ -4,6 +4,7 @@
 
 import sys
 import errno
+from future.utils import raise_from
 
 from saltlint.cli import run
 
@@ -15,4 +16,4 @@ if __name__ == "__main__":
         if exc.errno != errno.EPIPE:
             raise
     except RuntimeError as exc:
-        raise SystemExit(str(exc)) from exc
+        raise_from(SystemExit(str(exc)), exc)

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -6,6 +6,7 @@ import sys
 import pathspec
 import six
 import yaml
+from future.utils import raise_from
 
 import saltlint.utils
 
@@ -43,7 +44,7 @@ class SaltLintConfig(object):
             try:
                 config = yaml.safe_load(content)
             except Exception as exc:
-                raise SaltLintConfigError("invalid config: {}".format(exc)) from exc
+                raise_from(SaltLintConfigError("invalid config: {}".format(exc)), exc)
 
         # Parse verbosity
         self.verbosity = self._options.get('verbosity', 0)

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -43,7 +43,7 @@ class SaltLintConfig(object):
         if content:
             try:
                 config = yaml.safe_load(content)
-            except Exception as exc:
+            except yaml.YAMLError as exc:
                 raise_from(SaltLintConfigError("invalid config: {}".format(exc)), exc)
 
         # Parse verbosity

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -43,7 +43,7 @@ class SaltLintConfig(object):
             try:
                 config = yaml.safe_load(content)
             except Exception as exc:
-                raise SaltLintConfigError("invalid config: {}".format(exc))
+                raise SaltLintConfigError("invalid config: {}".format(exc)) from exc
 
         # Parse verbosity
         self.verbosity = self._options.get('verbosity', 0)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     },
     include_package_data=True,
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    install_requires=['six', 'pyyaml', 'pathspec>=0.6.0'],
+    install_requires=['six', 'pyyaml', 'pathspec>=0.6.0', 'future'],
     license=__license__,
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Add exception chaining and embedded tracebacks by using the raise from
statement.

For more information see: https://legacy.python.org/dev/peps/pep-3134/