### PR TITLE
Support doubly braced string format

### DIFF
--- a/saltlint/linter.py
+++ b/saltlint/linter.py
@@ -79,7 +79,8 @@ class RulesCollection(object):
         self.config = config
 
     def register(self, obj):
-        self.rules.append(obj)
+        if not any(rule.id == obj.id for rule in self.rules):
+            self.rules.append(obj)
 
     def __iter__(self):
         return iter(self.rules)

--- a/saltlint/rules/JinjaVariableHasSpacesRule.py
+++ b/saltlint/rules/JinjaVariableHasSpacesRule.py
@@ -15,7 +15,7 @@ class JinjaVariableHasSpacesRule(SaltLintRule):
     tags = ['formatting', 'jinja']
     version_added = 'v0.0.1'
 
-    bracket_regex = re.compile(r"{{[^ \-\+]|{{[-\+][^ ]|[^ \-\+]}}|[^ ][-\+]}}")
+    bracket_regex = re.compile(r"{{[^ \-\+\d]|{{[-\+][^ ]|[^ \-\+\d]}}|[^ {][-\+\d]}}")
 
     def match(self, file, line):
         return self.bracket_regex.search(line)

--- a/tests/unit/TestJinjaVariableHasSpaces.py
+++ b/tests/unit/TestJinjaVariableHasSpaces.py
@@ -18,7 +18,27 @@ BAD_VARIABLE_LINE = '''
 {{-variable+}}
 '''
 
-class TestLineTooLongRule(unittest.TestCase):
+BAD_VARIABLE_ENDING_IN_INTEGER = '''
+{{-variable0+}}
+'''
+
+BAD_VARIABLE_ENDING_IN_INTEGER_RIGHT = '''
+{{ variable0}}
+'''
+
+DOUBLE_QUOTED_INTEGER_IS_VALID = '''
+{{ "{{0}}" }}
+'''
+
+DOUBLE_QUOTED_INTEGER_TRAILING_SPACE_IS_INVALID = '''
+{{ "{{0}}"}}
+'''
+
+DOUBLE_QUOTED_INTEGER_LEADING_SPACE_IS_INVALID = '''
+{{"{{0}}" }}
+'''
+
+class TestJinjaVariableHasSpaces(unittest.TestCase):
     collection = RulesCollection()
 
     def setUp(self):
@@ -31,4 +51,24 @@ class TestLineTooLongRule(unittest.TestCase):
 
     def test_statement_negative(self):
         results = self.runner.run_state(BAD_VARIABLE_LINE)
+        self.assertEqual(1, len(results))
+
+    def test_double_quoted_integer(self):
+        results = self.runner.run_state(DOUBLE_QUOTED_INTEGER_IS_VALID)
+        self.assertEqual(0, len(results))
+
+    def test_double_quoted_integer_trailing_space_invalid(self):
+        results = self.runner.run_state(DOUBLE_QUOTED_INTEGER_TRAILING_SPACE_IS_INVALID)
+        self.assertEqual(1, len(results))
+
+    def test_double_quoted_integer_leading_space_invalid(self):
+        results = self.runner.run_state(DOUBLE_QUOTED_INTEGER_LEADING_SPACE_IS_INVALID)
+        self.assertEqual(1, len(results))
+
+    def test_variable_bad_ends_with_integer(self):
+        results = self.runner.run_state(BAD_VARIABLE_ENDING_IN_INTEGER)
+        self.assertEqual(1, len(results))
+
+    def test_variable_bad_ends_with_integer_right(self):
+        results = self.runner.run_state(BAD_VARIABLE_ENDING_IN_INTEGER_RIGHT)
         self.assertEqual(1, len(results))


### PR DESCRIPTION
This pull request fixes #192 by allowing certain combinations of doubly curl braces to exist without post or pre brace spaces. This is to allow string formatting strings such as `"{{0}}"` to exist within Jinja statements.

I think this covers enough of the use-case to be useful. We're linting and not syntax checking so I think this should be suitable.

I have included an increased amount of testing around the brace spaces rule as well.