### PR TITLE
Add link to dense-analysis/ale vim plugin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Application | GitHub Link | Store/Marketplace
 :-:|:--|:--
 Visual Studio Code | [warpnet/vscode-salt-lint](https://github.com/warpnet/vscode-salt-lint) | [VisualStudio Marketplace](https://marketplace.visualstudio.com/items?itemName=warpnet.salt-lint)
 Sublime Text | [warpnet/SublimeLinter-salt-lint](https://github.com/warpnet/SublimeLinter-salt-lint) | [Package Control](https://packagecontrol.io/packages/SublimeLinter-contrib-salt-lint)
-Vim dense-analysis/ale plugin| [warpnet/SublimeLinter-salt-lint](https://github.com/dense-analysis/ale) | [Package Control](https://github.com/dense-analysis/ale)
+Vim ([ALE plugin](https://github.com/dense-analysis/ale)) | [dense-analysis/ale](https://github.com/dense-analysis/ale) | [GitHub](https://github.com/dense-analysis/ale)
 
 Wish to create a `salt-lint` extension for your favourite editor? We're always looking for [contributions](CONTRIBUTING.md)!
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Application | GitHub Link | Store/Marketplace
 :-:|:--|:--
 Visual Studio Code | [warpnet/vscode-salt-lint](https://github.com/warpnet/vscode-salt-lint) | [VisualStudio Marketplace](https://marketplace.visualstudio.com/items?itemName=warpnet.salt-lint)
 Sublime Text | [warpnet/SublimeLinter-salt-lint](https://github.com/warpnet/SublimeLinter-salt-lint) | [Package Control](https://packagecontrol.io/packages/SublimeLinter-contrib-salt-lint)
+Vim dense-analysis/ale plugin| [warpnet/SublimeLinter-salt-lint](https://github.com/dense-analysis/ale) | [Package Control](https://github.com/dense-analysis/ale)
 
 Wish to create a `salt-lint` extension for your favourite editor? We're always looking for [contributions](CONTRIBUTING.md)!
 


### PR DESCRIPTION
Salt-lint support has just been added in ale vim plugin and I want to reflect that on salt-lint documentation.