### PR TITLE
fix: ensure all excluded paths are included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes in **salt-lint** are documented below.
 
 ## [Unreleased]
+### Fixed
+- Ensure all excluded paths from both the CLI and configuration are passed to the runner ([#231](https://github.com/warpnet/salt-lint/pull/231)).
+
 ## [0.5.0] (2021-01-17)
 ### Added
 - Rule 213 to recommend using cmd.run together with onchanges ([#207](https://github.com/warpnet/salt-lint/pull/207)).

--- a/saltlint/linter/runner.py
+++ b/saltlint/linter/runner.py
@@ -38,7 +38,8 @@ class Runner(object):
             # These will be (potentially) relative paths
             paths = [path.strip() for path in exclude_paths]
             self.exclude_paths = paths + [os.path.abspath(path) for path in paths]
-        self.exclude_paths = []
+        else:
+            self.exclude_paths = []
 
     def is_excluded(self, file_path):
         # Any will short-circuit as soon as something returns True, but will

--- a/tests/unit/TestRunner.py
+++ b/tests/unit/TestRunner.py
@@ -4,6 +4,9 @@
 import unittest
 
 from saltlint.cli import run
+from saltlint.config import Configuration
+from saltlint.linter.runner import Runner
+
 
 class TestRunner(unittest.TestCase):
 
@@ -18,3 +21,16 @@ class TestRunner(unittest.TestCase):
         # expected.
         args = ['tests/test-extension-success.sls']
         self.assertEqual(run(args), 0)
+
+    def test_runner_exclude_paths(self):
+        """
+        Check if all the excluded paths from the configuration are passed to
+        the runner.
+        """
+        exclude_paths = ['first.sls', 'second.sls']
+        config = Configuration(dict(exclude_paths=exclude_paths))
+        runner = Runner([], 'init.sls', config)
+
+        self.assertTrue(
+            any(path in runner.exclude_paths for path in exclude_paths)
+        )


### PR DESCRIPTION
Ensure all the excluded paths provided in the configuration and/or via
the CLI are passed to the runner.

Fixes #230
