### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes in **salt-lint** are documented below.
 
 ## [Unreleased]
+## [0.5.1] (2021-01-19)
 ### Fixed
 - Ensure all excluded paths from both the CLI and configuration are passed to the runner ([#231](https://github.com/warpnet/salt-lint/pull/231)).
 
@@ -13,4 +14,5 @@ All notable changes in **salt-lint** are documented below.
 - This `CHANGELOG.md` file to be able to list all notable changes for each version of **salt-lint** ([#223](https://github.com/warpnet/salt-lint/pull/223)).
 
 [Unreleased]: https://github.com/warpnet/salt-lint/compare/v0.4.2...HEAD
+[0.5.1]: https://github.com/warpnet/salt-lint/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/warpnet/salt-lint/compare/v0.4.2...v0.5.0

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ To use salt-lint with [pre-commit](https://pre-commit.com),  just add the follow
 # See usage instructions at http://pre-commit.com
 
 -   repo: https://github.com/warpnet/salt-lint
-    rev: v0.5.0
+    rev: v0.5.1
     hooks:
       - id: salt-lint
 ```

--- a/saltlint/__init__.py
+++ b/saltlint/__init__.py
@@ -5,7 +5,7 @@
 """
 
 NAME = 'salt-lint'
-VERSION = '0.5.0'
+VERSION = '0.5.1'
 DESCRIPTION = __doc__
 
 __author__ = 'Warpnet B.V.'


### PR DESCRIPTION
Bump version to **0.5.1** and update the `CHANGELOG.md` file accordingly.

**Note:** create a new release after merging this PR.
