### PR TITLE
fix: append changelog to long description in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes in **salt-lint** are documented below.
 
 ## [Unreleased]
+### Fixed
+- Append the contents of the `CHANGELOG.md` file to the long description of the package instead of the duplicate `README.md` contents ([#234](https://github.com/warpnet/salt-lint/pull/234)).
+
 ## [0.5.1] (2021-01-19)
 ### Fixed
 - Ensure all excluded paths from both the CLI and configuration are passed to the runner ([#231](https://github.com/warpnet/salt-lint/pull/231)).

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include README.md CHANGELOG.md CODE_OF_CONDUCT.md
+include LICENSE LICENSE.ansible-lint
+include tox.ini
+recursive-include docs *.py *.rst Makefile make.bat requirements.txt
+recursive-include tests test-extension-failure test-extension-failure.extra.sls test-extension-success.sls

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def long_description():
         readme = readme_file.read()
 
     # Read content from the CHANGELOG.md file
-    with open('README.md') as changelog_file:
+    with open('CHANGELOG.md') as changelog_file:
         changelog = changelog_file.read()
 
     return readme + changelog


### PR DESCRIPTION
Append the contents of the `CHANGELOG.md` file to the long description of the package instead of the duplicate `README.md` contents.