### PR TITLE
test: add type hint test using mypy

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -33,3 +33,6 @@ jobs:
       - name: Run Tox
         # Run tox using the version of Python in `PATH`
         run: tox -e py
+
+      - name: Run type hint checks
+        run: tox -e mypy

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -3,7 +3,7 @@
 
 import os
 import sys
-import pathspec
+import pathspec  # type: ignore
 import yaml
 
 import saltlint.utils

--- a/saltlint/linter/rule.py
+++ b/saltlint/linter/rule.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
 # Modified work Copyright (c) 2020 Warpnet B.V.
 
+from typing import List, Optional
 import re
 
 from saltlint.utils import get_rule_skips_from_line, get_file_type
@@ -11,10 +12,10 @@ from saltlint.utils import LANGUAGE_SLS, LANGUAGE_JINJA
 
 class Rule(object):
 
-    id = None
-    shortdesc = None
-    description = None
-    languages = []
+    id: Optional[str] = None
+    shortdesc: Optional[str] = None
+    description: Optional[str] = None
+    languages: List[str] = []
     match = None
     matchtext = None
 
@@ -127,9 +128,9 @@ class JinjaRule(Rule):
 
 
 class DeprecationRule(Rule):
-    id = None
-    state = None
-    deprecated_since = None
+    id: Optional[str] = None
+    state: Optional[str] = None
+    deprecated_since: Optional[str] = None
 
     severity = 'HIGH'
     languages = [LANGUAGE_SLS]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = lint,{py36,py37,py38,py39}-install
+envlist = lint,{py36,py37,py38,py39}-install,mypy
 skip_missing_interpreters = True
 
 [testenv]
@@ -56,3 +56,12 @@ commands =
   {envpython} -m pre_commit run {posargs:--all-files --hook-stage manual -v}
 passenv =
   PRE_COMMIT_HOME
+
+[testenv:mypy]
+description = Check Python type hints
+basepython = python3
+deps = mypy
+commands =
+  mypy --config-file=tox.ini saltlint tests
+
+[mypy]


### PR DESCRIPTION
After dropping the Python 2.7 support in #239, Python type hint can be used. This PR will add a mypy type hint test using tox and fixes all required type hint to allow the new test to pass.