### PR TITLE
Replace imp by importlib

### DIFF
--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -27,7 +27,7 @@ def run(args=None):
 
     # Read input from STDIN
     if not sys.stdin.isatty():
-        stdin_file = tempfile.NamedTemporaryFile('w', suffix='.sls', delete=False)
+        stdin_file = tempfile.NamedTemporaryFile('w', suffix='.sls', delete=False)  # pylint: disable=R1732
         stdin_file.write(sys.stdin.read())
         stdin_file.flush()
         file_names.add(stdin_file.name)

--- a/saltlint/utils.py
+++ b/saltlint/utils.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
-# Modified work Copyright (c) 2020 Warpnet B.V.
+# Modified work Copyright (c) 2020-2021 Warpnet B.V.
 
 import glob
-import imp
+import importlib.util
 import os
 
 
@@ -19,9 +19,10 @@ def load_plugins(directory, config):
 
         pluginname = os.path.basename(pluginfile.replace('.py', ''))
         try:
-            fh, filename, desc = imp.find_module(pluginname, [directory])
-            mod = imp.load_module(pluginname, fh, filename, desc)
-            obj = getattr(mod, pluginname)(config)
+            spec = importlib.util.spec_from_file_location(pluginname, pluginfile)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            obj = getattr(module, pluginname)(config)
             result.append(obj)
         finally:
             if fh:

--- a/tests/unit/TestConfig.py
+++ b/tests/unit/TestConfig.py
@@ -31,7 +31,7 @@ class TestConfig(unittest.TestCase):
     def setUp(self):
         # Open the temporary configuration file and write the contents of
         # SALT_LINT_CONFIG to the temporary file.
-        fp = tempfile.NamedTemporaryFile()
+        fp = tempfile.NamedTemporaryFile()  # pylint: disable=R1732
         fp.write(SALT_LINT_CONFIG.encode())
         fp.seek(0)
         self.fp = fp


### PR DESCRIPTION
Replace `imp` by `importlib` in `saltlint/utils.py` as `imp` has been deprecated and ignore all `consider-using-with` errors.