### PR TITLE
chore: bump version to v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 All notable changes in **salt-lint** are documented below.
 
 ## [Unreleased]
+
+## [0.6.0] (2021-06-01)
 ### Deprecated
-- Drop Python 2.7 support ((#239)[https://github.com/warpnet/salt-lint/pull/239]).
+- Drop Python 2.7 support ([#239](https://github.com/warpnet/salt-lint/pull/239)).
 
 ### Added
-- Rule 216, 217 and 218 for catching common typographical errors ((#249)[https://github.com/warpnet/salt-lint/pull/249]).
+- Rule 216, 217 and 218 for catching common typographical errors ([#249](https://github.com/warpnet/salt-lint/pull/249)).
 
 ## [0.5.2] (2021-01-29)
 ### Fixed
@@ -24,7 +26,8 @@ All notable changes in **salt-lint** are documented below.
 - Rules 901-915 to check for deprecated states and state options ([#214](https://github.com/warpnet/salt-lint/pull/214)).
 - This `CHANGELOG.md` file to be able to list all notable changes for each version of **salt-lint** ([#223](https://github.com/warpnet/salt-lint/pull/223)).
 
-[Unreleased]: https://github.com/warpnet/salt-lint/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/warpnet/salt-lint/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/warpnet/salt-lint/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/warpnet/salt-lint/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/warpnet/salt-lint/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/warpnet/salt-lint/compare/v0.4.2...v0.5.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -173,7 +173,7 @@ To use salt-lint with [pre-commit](https://pre-commit.com),  just add the follow
 # See usage instructions at http://pre-commit.com
 
 -   repo: https://github.com/warpnet/salt-lint
-    rev: v0.5.1
+    rev: v0.6.0
     hooks:
       - id: salt-lint
 ```

--- a/saltlint/__init__.py
+++ b/saltlint/__init__.py
@@ -5,7 +5,7 @@
 """
 
 NAME = 'salt-lint'
-VERSION = '0.5.2'
+VERSION = '0.6.0'
 DESCRIPTION = __doc__
 
 __author__ = 'Warpnet B.V.'

--- a/saltlint/rules/TypoContentsRule.py
+++ b/saltlint/rules/TypoContentsRule.py
@@ -12,5 +12,5 @@ class TypoContentsRule(TypographicalErrorRule):
     id = '218'
     shortdesc = '"content" looks like a typo. Did you mean "contents"?'
     description = '"content" looks like a typo. Did you mean "contents"?'
-    version_added = 'develop'
+    version_added = 'v0.6.0'
     regex = re.compile(r"^\s+- content(|_pillar|_grains|_newline|_delimiter):")

--- a/saltlint/rules/TypoOnchangesRule.py
+++ b/saltlint/rules/TypoOnchangesRule.py
@@ -12,5 +12,5 @@ class TypoOnchangesRule(TypographicalErrorRule):
     id = '216'
     shortdesc = '"onchange" looks like a typo. Did you mean "onchanges"?'
     description = '"onchange" looks like a typo. Did you mean "onchanges"?'
-    version_added = 'develop'
+    version_added = 'v0.6.0'
     regex = re.compile(r"^\s+- onchange(|_in|_any):")

--- a/saltlint/rules/TypoRequireRule.py
+++ b/saltlint/rules/TypoRequireRule.py
@@ -12,5 +12,5 @@ class TypoRequireRule(TypographicalErrorRule):
     id = '217'
     shortdesc = '"requires" looks like a typo. Did you mean "require"?'
     description = '"requires" looks like a typo. Did you mean "require"?'
-    version_added = 'develop'
+    version_added = 'v0.6.0'
     regex = re.compile(r"^\s+- requires(|_in|_any):")


### PR DESCRIPTION
### Introduction
Version 0.6.0 release.

### Deprecated
- Drop Python 2.7 support ([#239](https://github.com/warpnet/salt-lint/pull/239)).

### Added
- Rule 216, 217 and 218 for catching common typographical errors ([#249](https://github.com/warpnet/salt-lint/pull/249)).