### PR TITLE
docs: 211: Fix an inconsistency in pillar.get formatting

### DIFF
--- a/docs/rules/formatting.md
+++ b/docs/rules/formatting.md
@@ -246,7 +246,7 @@ ___
 
 Correct ways:
 * `salt['pillar.get']('item')`
-* `pillar.get['item']`
+* `pillar['item']`
 * `pillar.get('item')`
 
 Incorrect ways:


### PR DESCRIPTION
I was confused for a while trying to figure out why the same syntax was both correct and incorrect.