### PR TITLE
Version bump pre-commit repos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
-  rev: v3.3.0
+  rev: v4.0.1
   hooks:
   - id: end-of-file-fixer
   - id: trailing-whitespace
@@ -14,24 +14,24 @@ repos:
 #   - id: markdownlint
 #     args: ["-r ~MD013,~MD029,~MD041"]
 - repo: https://github.com/IamTheFij/docker-pre-commit.git
-  rev: v2.0.0
+  rev: v2.0.1
   hooks:
   - id: hadolint
     files: docker/Dockerfile
 - repo: https://gitlab.com/pycqa/flake8.git
-  rev: 3.8.4
+  rev: 3.9.2
   hooks:
   - id: flake8
     exclude: '^$|.git|tests|env|docs'
 - repo: https://github.com/codespell-project/codespell.git
-  rev: v2.0.0
+  rev: v2.1.0
   hooks:
   - id: codespell
     args:
     - '--skip="./.git*,./saltlint/rules/FileManagedReplaceContentRule.py"'
     - '-L alse'
 - repo: https://github.com/PyCQA/pylint.git
-  rev: master
+  rev: v2.9.5
   hooks:
   - id: pylint
     exclude: ^docs/

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,6 @@ description = Check Python type hints
 basepython = python3
 deps = mypy
 commands =
-  mypy --config-file=tox.ini saltlint tests
+  mypy --config-file=tox.ini --install-types --non-interactive saltlint tests
 
 [mypy]


### PR DESCRIPTION
Version bump pre-commit repos to allow Github Actions to successfully lint the files in the `tests` workflow.