### PR TITLE
Add Python 3.10 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
 

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Bug Tracking',
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = lint,{py36,py37,py38,py39}-install,mypy
+envlist = lint,{py36,py37,py38,py39,py310}-install,mypy
 skip_missing_interpreters = True
 
 [testenv]
@@ -27,10 +27,6 @@ commands =
     python setup.py bdist_wheel
     pip install --no-index --find-links=dist salt-lint
 
-[testenv:py27-install]
-skip_install = {[testenv:install]skip_install}
-commands = {[testenv:install]commands}
-
 [testenv:py36-install]
 skip_install = {[testenv:install]skip_install}
 commands = {[testenv:install]commands}
@@ -44,6 +40,10 @@ skip_install = {[testenv:install]skip_install}
 commands = {[testenv:install]commands}
 
 [testenv:py39-install]
+skip_install = {[testenv:install]skip_install}
+commands = {[testenv:install]commands}
+
+[testenv:py310-install]
 skip_install = {[testenv:install]skip_install}
 commands = {[testenv:install]commands}
 


### PR DESCRIPTION
Add Python 3.10 support by:
- Adding Python 3.10 as supported version in the classifiers in `setup.py`.
- Adding it as a tox environment.
- Adding it as additional Python version in the GitHub workflow called `tests`.