### PR TITLE
Fix typo

### DIFF
--- a/docs/rules/formatting.md
+++ b/docs/rules/formatting.md
@@ -72,7 +72,7 @@ ___
 
 ## 204
 
-**Lines should be no longer that 160 chars**
+**Lines should be no longer than 160 chars**
 
 ### Problematic code
 ```yaml

--- a/saltlint/rules/LineTooLongRule.py
+++ b/saltlint/rules/LineTooLongRule.py
@@ -8,7 +8,7 @@ from saltlint.linter.rule import Rule
 
 class LineTooLongRule(Rule):
     id = '204'
-    shortdesc = 'Lines should be no longer that 160 chars'
+    shortdesc = 'Lines should be no longer than 160 chars'
     description = (
         'Long lines make code harder to read and '
         'code review more difficult'


### PR DESCRIPTION
Changes `longer that` to `longer than`