### PR TITLE
Add rule 218 File mode Single quotation rule

### DIFF
--- a/saltlint/rules/FileModeSingleQuotationRule.py
+++ b/saltlint/rules/FileModeSingleQuotationRule.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2016 Will Thames and contributors
+# Copyright (c) 2018 Ansible Project
+# Modified work Copyright (c) 2020 Warpnet B.V.
+
+import re
+from saltlint.linter.rule import Rule
+from saltlint.utils import LANGUAGE_SLS
+
+
+class FileModeSingleQuotationRule(Rule):
+    id = '218'
+    shortdesc = 'File modes should always be encapsulated in single quotation marks'
+    description = 'File modes should always be encapsulated in single quotation marks'
+    severity = 'HIGH'
+    languages = [LANGUAGE_SLS]
+    tags = ['formatting']
+    version_added = 'v0.8.0'
+
+    regex = re.compile(
+        r"""^\s+
+        -\                   # whitespace escaped due to re.VERBOSE
+        (?:dir_|file_)?mode  # file_mode, dir_mode or mode
+        :\                   # whitespace escaped duo to re.VERBOSE
+        (?:
+            (?:
+                ["]         # followed by a quotation character
+              |
+                \s           # followed by a whitespace
+              |
+                $            # followed by EOL
+            )
+          |
+            (["]\d{3,4}["]     # mode prefixed with quotation
+              (?:[^\d"]|$)  # not followed by digit, quoation or EOL
+            )
+        )
+        """,
+        re.VERBOSE
+    )
+
+    def match(self, file, line):
+        # TODO: when salt-lint becomes state aware it should ignore the mode
+        # argument in the network.managed state.
+        return self.regex.search(line)

--- a/tests/unit/TestFileModeSingleQuotationRule.py
+++ b/tests/unit/TestFileModeSingleQuotationRule.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2013-2018 Will Thames <will@thames.id.au>
+# Copyright (c) 2018 Ansible by Red Hat
+# Modified work Copyright (c) 2020 Warpnet B.V.
+
+import unittest
+
+from saltlint.linter.collection import RulesCollection
+from saltlint.rules.FileModeSingleQuotationRule import FileModeSingleQuotationRule
+from tests import RunFromText
+
+
+BAD_MODE_SINGLE_QUOTATION_LINE = '''
+testfile:
+  file.managed:
+    - name: /tmp/badfile
+    - user: root
+    - group: root
+    - mode: "0700"
+    - file_mode: "0660"
+    - dir_mode: "0775"
+'''
+
+GOOD_MODE_SINGLE_QUOTATION_LINE = '''
+testfile:
+  file.managed:
+    - name: /tmp/goodfile
+    - user: root
+    - group: root
+    - mode: '0700'
+    - file_mode: '0660'
+    - dir_mode: '0775'
+'''
+
+
+class TestModeQuotationRule(unittest.TestCase):
+    collection = RulesCollection()
+
+    def setUp(self):
+        self.collection.register(FileModeSingleQuotationRule())
+        self.runner = RunFromText(self.collection)
+
+    def test_statement_single_negative(self):
+        results = self.runner.run_state(BAD_MODE_SINGLE_QUOTATION_LINE)
+        self.assertEqual(3, len(results))
+
+    def test_statement_single_positive(self):
+        results = self.runner.run_state(GOOD_MODE_SINGLE_QUOTATION_LINE)
+        self.assertEqual(0, len(results))


### PR DESCRIPTION
In documentation is written:

```
When using a mode that includes a leading zero you must wrap 
the value in single quotes. If the value is not wrapped in quotes 
it will be read by YAML as an integer and evaluated as an octal.
```

