### PR TITLE
[FEATURE] Add regex for alternate typo of onchanges

### DIFF
--- a/saltlint/rules/TypoOnchangesRule.py
+++ b/saltlint/rules/TypoOnchangesRule.py
@@ -13,4 +13,4 @@ class TypoOnchangesRule(TypographicalErrorRule):
     shortdesc = '"onchange" looks like a typo. Did you mean "onchanges"?'
     description = '"onchange" looks like a typo. Did you mean "onchanges"?'
     version_added = 'v0.6.0'
-    regex = re.compile(r"^\s+- onchange(|_in|_any):")
+    regex = re.compile(r"^\s+- (on_?change(|_in|_any)|on_changes(|_in|_any)):")

--- a/tests/unit/TestTypoOnchangesRule.py
+++ b/tests/unit/TestTypoOnchangesRule.py
@@ -41,6 +41,20 @@ testfile:
     - onchange_any:
         - yetanotherfile
         - onemorefile
+    - on_change:
+        - otherfile
+    - on_change_in:
+        - anotherfile
+    - on_change_any:
+        - yetanotherfile
+        - onemorefile
+    - on_changes:
+        - otherfile
+    - on_changes_in:
+        - anotherfile
+    - on_changes_any:
+        - yetanotherfile
+        - onemorefile
 '''
 
 class TestTypoOnchangesRule(unittest.TestCase):
@@ -56,4 +70,4 @@ class TestTypoOnchangesRule(unittest.TestCase):
 
     def test_statement_negative(self):
         results = self.runner.run_state(BAD_ONCHANGES_LINE)
-        self.assertEqual(3, len(results))
+        self.assertEqual(9, len(results))


### PR DESCRIPTION
Add to the existing rule to catch `onchanges` typos:

```
on_change:
on_change_any:
on_change_in:
on_changes:
on_changes_any:
on_changes_in:
```