### PR TITLE
Fix GitHub workflow for running tox

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python: ['3.6', '3.7', '3.8', '3.9', '3.10']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   - id: hadolint
     files: docker/Dockerfile
 - repo: https://github.com/pycqa/flake8.git
-  rev: 3.9.2
+  rev: 5.0.4
   hooks:
   - id: flake8
     exclude: '^$|.git|tests|env|docs'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   hooks:
   - id: hadolint
     files: docker/Dockerfile
-- repo: https://gitlab.com/pycqa/flake8.git
+- repo: https://github.com/pycqa/flake8.git
   rev: 3.9.2
   hooks:
   - id: flake8


### PR DESCRIPTION
Fix the GitHub workflow run for running tox by:
- Set platform version to Ubuntu 20.04 for running tox in the GitHub workflows as there is no Python 3.6 available on latest Ubuntu version, for more information see: https://github.com/actions/setup-python/issues/544#issuecomment-1320295576.
- Update Flake8 to be able to run on all Python versions.