### PR TITLE
fix: octal rule triggers on time format

### DIFF
--- a/saltlint/rules/YamlHasOctalValueRule.py
+++ b/saltlint/rules/YamlHasOctalValueRule.py
@@ -17,7 +17,7 @@ class YamlHasOctalValueRule(Rule):
     tags = ['formatting']
     version_added = 'v0.0.6'
 
-    bracket_regex = re.compile(r"^[^:]+:\s{0,}0[0-9]{1,}\s{0,}((?={#)|(?=#)|(?=$))")
+    bracket_regex = re.compile(r"^.*(?:\s|[^\d]{2}:)0\d+(?:[\s#{]|$)")
 
     def match(self, file, line):
         return self.bracket_regex.search(line)

--- a/tests/unit/TestYamlHasOctalValueRule.py
+++ b/tests/unit/TestYamlHasOctalValueRule.py
@@ -31,9 +31,20 @@ apache_disable_default_site:
 
 # MAC addresses shouldn't be matched, for more information see:
 # https://github.com/warpnet/salt-lint/issues/202
-infoblox_remove_record:
+infoblox_remove_record1:
   infoblox_host_record.absent:
     - mac: 4c:f2:d3:1b:2e:05
+
+infoblox_remove_record2:
+  infoblox_host_record.absent:
+    - mac: 05:f2:d3:1b:2e:4c
+
+# Time values should not trigger this rule
+some_calendar_entry:
+  file.managed:
+    - name: /tmp/my_unit_file
+    - contents: |
+        OnCalendar=Sun 18:00
 '''
 
 BAD_NUMBER_STATE = '''


### PR DESCRIPTION
Time values such as this:

```
some_calendar_entry:
  file.managed:
    - name: /tmp/my_unit_file
    - contents: |
        OnCalendar=Sun 18:00
```

should not trigger this rule.

Changed the regex to accommodate this case while still catching/ignoring previous identified test cases