### PR TITLE
fix: octal rule triggers on time format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Add Python 3.12 support ([#315](https://github.com/warpnet/salt-lint/pull/315)).
 
+### Fixed
+- Ignore false positive result in rule 210 ([#303](https://github.com/warpnet/salt-lint/pull/303)).
+
 ## [0.9.2] (2023-02-09)
 ### Fixed
 - Ensure version identification adheres to [PEP440](https://peps.python.org/pep-0440/) ([!304](https://github.com/warpnet/salt-lint/issues/304))

--- a/saltlint/rules/YamlHasOctalValueRule.py
+++ b/saltlint/rules/YamlHasOctalValueRule.py
@@ -19,5 +19,12 @@ class YamlHasOctalValueRule(Rule):
 
     bracket_regex = re.compile(r"^[^:]+:\s{0,}0[0-9]{1,}\s{0,}((?={#)|(?=#)|(?=$))")
 
+    exclude_regex = re.compile(r"[ T]\d\d:\d\d(?:[: ]|$)")
+
     def match(self, file, line):
-        return self.bracket_regex.search(line)
+        found = self.bracket_regex.search(line)
+        if found:
+            exc = self.exclude_regex.search(found.group(0))
+            if exc:
+                return None
+        return found

--- a/saltlint/rules/YamlHasOctalValueRule.py
+++ b/saltlint/rules/YamlHasOctalValueRule.py
@@ -24,7 +24,7 @@ class YamlHasOctalValueRule(Rule):
     def match(self, file, line):
         found = self.bracket_regex.search(line)
         if found:
-            exc = self.exclude_regex.search(found.group(0))
-            if exc:
+            # Skip false positive result if the exclude_regex matches.
+            if self.exclude_regex.search(found.group(0)):
                 return None
         return found

--- a/tests/unit/TestYamlHasOctalValueRule.py
+++ b/tests/unit/TestYamlHasOctalValueRule.py
@@ -31,9 +31,20 @@ apache_disable_default_site:
 
 # MAC addresses shouldn't be matched, for more information see:
 # https://github.com/warpnet/salt-lint/issues/202
-infoblox_remove_record:
+infoblox_remove_record1:
   infoblox_host_record.absent:
     - mac: 4c:f2:d3:1b:2e:05
+
+infoblox_remove_record2:
+  infoblox_host_record.absent:
+    - mac: 05:f2:d3:1b:2e:4c
+
+# time values should not trigger this rule
+some_calendar_entry:
+  file.managed:
+    - name: /tmp/my_unit_file
+    - contents: |
+        oncalendar=Sun 18:00
 '''
 
 BAD_NUMBER_STATE = '''


### PR DESCRIPTION
Time values such as this:

```
some_calendar_entry:
  file.managed:
    - name: /tmp/my_unit_file
    - contents: |
        OnCalendar=Sun 18:00
```

should not trigger this rule.

Changed the regex to accommodate this case while still catching/ignoring previous identified test cases