### PR TITLE
Lookup for configuration in parent folder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - Add Python 3.12 support ([#315](https://github.com/warpnet/salt-lint/pull/315)).
+- Lookup configuration file in parent directory ([#305](https://github.com/warpnet/salt-lint/pull/305)).
 
 ### Fixed
 - Ignore false positive result in rule 210 ([#303](https://github.com/warpnet/salt-lint/pull/303)).

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,6 +136,8 @@ jobs:
 
 Salt-lint supports local configuration via a `.salt-lint` configuration file. Salt-lint checks the working directory for the presence of this file and applies any configuration found there. The configuration file location can also be overridden via the `-c path/to/file` CLI flag.
 
+If salt-lint cannot find a configuration file in the current directory it attempts to locate it in a parent directory. However salt-lint does not try to load configuration that is outside the git repository.
+
 If a value is provided on both the command line and via a configuration file, the values will be merged (if a list like **exclude_paths**), or the **True** value will be preferred, in the case of something like **quiet**.
 
 The following values are supported, and function identically to their CLI counterparts:

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -26,8 +26,8 @@ class Configuration(object):
         if config is None:
             config = get_config_path()
 
-        # Read the file contents
-        if os.path.exists(config):
+        # Read the configuration file contents if it exists.
+        if config and os.path.exists(config):
             with open(config, 'r', encoding="UTF-8") as f:
                 content = f.read()
         else:
@@ -134,7 +134,7 @@ class Configuration(object):
         return self.rules[rule]['ignore'].match_file(filepath)
 
 def get_config_path():
-    """Return local config file."""
+    """Return local configuration file."""
     dirname = basename = os.getcwd()
     while basename:
         filename = os.path.abspath(os.path.join(dirname, ".salt-lint"))
@@ -146,3 +146,4 @@ def get_config_path():
             # project has no config.
             return None
         (dirname, basename) = os.path.split(dirname)
+    return None

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -133,6 +133,7 @@ class Configuration(object):
             return False
         return self.rules[rule]['ignore'].match_file(filepath)
 
+
 def get_config_path():
     """Return local configuration file."""
     dirname = basename = os.getcwd()


### PR DESCRIPTION
This change will lookup for a `.salt-lint` configuration in the parent folder if no configuration is present in the current folder. It will stop going to upper level if reach the git repository root.
Which is useful if you have sub formulas, but only have the `.salt-lint` config in the repository root. 

This change is inspired by ansible-lint.