### PR TITLE
Ensure python_requires adheres to pep440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         ]
     },
     include_package_data=True,
-    python_requires='>=3.6.*',
+    python_requires='>=3.6',
     install_requires=['pyyaml', 'pathspec>=0.6.0'],
     license=__license__,
     zip_safe=False,


### PR DESCRIPTION
Should fix https://github.com/warpnet/salt-lint/issues/304