### PR TITLE
fix: install of salt-lint in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /src
 COPY . /src/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux \
- && python3 setup.py install \
+ && python3 -m pip install . \
  && salt-lint --version \
  && find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
  && find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf


### PR DESCRIPTION
Fix install of salt-lint in Dockerfile after the project changed from `setup.py` to `pyproject.yoml`.