### PR TITLE
Added rule [220] to check for a new line in End Of File

### DIFF
--- a/docs/rules/formatting.md
+++ b/docs/rules/formatting.md
@@ -398,3 +398,42 @@ As described by the [official SaltStack documentation](https://docs.saltproject.
         custom_var: "default value"
         other_var: 123
 ```
+
+___
+
+## 220
+
+**SLS and JINJA files must end with only one newline character**
+
+As described by the [POSIX standard](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206)
+>3.206 Line
+> 
+>A sequence of zero or more non- 'newline' characters plus a terminating 'newline' character.
+
+### Problematic code
+```yaml
+# No <newline> in <End Of File>
+debug_output:
+  cmd.run:
+    - name: echo hello<EOF>
+```
+
+### Problematic code
+```yaml
+# 2 or more <newline> in <End Of File>
+debug_output:
+  cmd.run:
+    - name: echo hello
+
+<EOF>
+```
+
+
+### Correct code
+```yaml
+# 1 <newline> in <End Of File>
+debug_output:
+  cmd.run:
+    - name: echo hello
+<EOF>
+```

--- a/saltlint/rules/EOFRule.py
+++ b/saltlint/rules/EOFRule.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024 Anton Ovseenko
+
+import re
+from saltlint.linter.rule import Rule
+
+
+class EOFRule(Rule):
+    id = '220'
+    shortdesc = 'Number of newline in EOF'
+    description = 'There should be exactly one new line at the end of the file'
+    severity = 'INFO'
+    tags = ['formatting']
+    version_added = 'v0.9.2'
+
+    eof_regex = re.compile(r"\n+\Z")
+
+    def matchtext(self, file, text):
+        if len(text) == 0:
+            return []
+
+        match = self.eof_regex.search(text)
+        if match:
+            n = len(match.group())
+            end = match.end()
+            line_no = len(text[:end].splitlines())
+            return [(line_no, match.group().encode(), f"{n} newline in EOF")] if n != 1 else []
+
+        return [(len(text.splitlines()), "<End Of File>", f"No newline in EOF")]
+

--- a/tests/unit/TestEOFRule.py
+++ b/tests/unit/TestEOFRule.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024 Anton Ovseenko
+
+import unittest
+
+from saltlint.linter.collection import RulesCollection
+from saltlint.rules.EOFRule import EOFRule
+from tests import RunFromText
+
+NO_NEWLINE = '''
+debug_output:
+  cmd.run:
+    - name: echo hello'''
+
+ONE_NEWLINE = '''
+debug_output:
+  cmd.run:
+    - name: echo hello
+'''
+
+TWO_NEWLINE = '''
+debug_output:
+  cmd.run:
+    - name: echo hello
+
+'''
+
+
+class TestEOFRule(unittest.TestCase):
+    collection = RulesCollection()
+
+    def setUp(self):
+        self.collection.register(EOFRule())
+        self.runner = RunFromText(self.collection)
+
+    def test_eof_positive(self):
+        results = self.runner.run_state(ONE_NEWLINE)
+        self.assertEqual(0, len(results))
+
+    def test_eof_negative(self):
+        results = self.runner.run_state(TWO_NEWLINE)
+        self.assertEqual(1, len(results))
+
+    def test_eof_no_newline_negative(self):
+        results = self.runner.run_state(NO_NEWLINE)
+        self.assertEqual(1, len(results))


### PR DESCRIPTION
Added rule and documentation for checking number of newline in EOF jinja and sls files. This is necessary for a uniform file style in projects, so that there is only 1 newline character at the end of each file (not 0, not 2+).