### PR TITLE
feat: Add pillar get on nested structure

### DIFF
--- a/saltlint/rules/PillarGetNestedStructure.py
+++ b/saltlint/rules/PillarGetNestedStructure.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 IT Services, Stockholm University
+
+import re
+from saltlint.linter.rule import JinjaRule
+
+
+class PillarGetNestedStructure(JinjaRule):
+    id = '220'
+    shortdesc = 'Trying to get nested pillar structures with .get() or []'
+    description = "Using pillar.get() or pillar[] to get a:nested:structure "
+    "doesn't work. It tries to get a key named 'a:nested:structure' instead "
+    "of the value of ['a']['nested']['structure'] in the dict. See "
+    "https://docs.saltproject.io/salt/user-guide/en/latest/topics/pillar.html#rendering-pillar"
+    severity = 'HIGH'
+    version_added = 'develop'
+
+    regex = re.compile(r"pillar.get\(.+?:.+?\)|pillar\[.+?:.+?\]")
+
+    def match(self, file, text):
+        return self.regex.search(text)


### PR DESCRIPTION
Add check for pillar get on nested structure as per the note at https://docs.saltproject.io/salt/user-guide/en/latest/topics/pillar.html#rendering-pillar

This has bit me a lot of times "why am I getting None? I should be getting a list/dict! to iterate over!"

I opened it as a draft since I want to add tests and I wasn't sure the proper procedure for contributing.