### PR TITLE
feat: add Python 3.13 and 3.14 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
 
@@ -31,7 +31,7 @@ jobs:
         run: tox -e lint
         # Skip linting on EOL and newer Python version because the pre-commit
         # actions required supported versions.
-        if: ${{ matrix.python != '3.6' && matrix.python != '3.12' }}
+        if: ${{ matrix.python != '3.6' && matrix.python != '3.14' }}
 
       - name: Run Tox
         # Run tox using the version of Python in `PATH`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
-  rev: v4.0.1
+  rev: v6.0.0
   hooks:
   - id: end-of-file-fixer
   - id: trailing-whitespace
@@ -19,19 +19,19 @@ repos:
   - id: hadolint
     files: docker/Dockerfile
 - repo: https://github.com/pycqa/flake8.git
-  rev: 5.0.4
+  rev: 7.3.0
   hooks:
   - id: flake8
     exclude: '^$|.git|tests|env|docs'
 - repo: https://github.com/codespell-project/codespell.git
-  rev: v2.1.0
+  rev: v2.4.2
   hooks:
   - id: codespell
     args:
     - '--skip="./.git*,./saltlint/rules/FileManagedReplaceContentRule.py"'
     - '-L alse'
 - repo: https://github.com/PyCQA/pylint.git
-  rev: v2.15.9
+  rev: v4.0.5
   hooks:
   - id: pylint
     exclude: ^docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Drop Python 3.6 support ([#319](https://github.com/warpnet/salt-lint/pull/319)).
 
 ### Added
+- Add Python 3.13 and 3.14 support.
 - Add Python 3.12 support ([#315](https://github.com/warpnet/salt-lint/pull/315)).
 - Lookup configuration file in parent directory ([#305](https://github.com/warpnet/salt-lint/pull/305)).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Bug Tracking",
   "Topic :: Software Development :: Quality Assurance",
   "Topic :: Software Development :: Testing",

--- a/saltlint/linter/collection.py
+++ b/saltlint/linter/collection.py
@@ -4,7 +4,6 @@
 
 from collections import defaultdict
 import os
-import codecs
 import sys
 
 from saltlint.config import Configuration
@@ -35,7 +34,7 @@ class RulesCollection(object):
         matches = []
 
         try:
-            with codecs.open(statefile['path'], mode='rb', encoding='utf-8') as f:
+            with open(statefile['path'], mode='r', encoding='utf-8') as f:
                 text = f.read()
         except IOError as e:
             print("WARNING: Couldn't open %s - %s" %

--- a/saltlint/linter/match.py
+++ b/saltlint/linter/match.py
@@ -5,7 +5,7 @@
 
 class Match(object):
 
-    def __init__(self, linenumber, line, filename, rule, message=None):
+    def __init__(self, linenumber, line, filename, rule, *, message=None):
         self.linenumber = linenumber
         self.line = line
         self.filename = filename

--- a/saltlint/linter/rule.py
+++ b/saltlint/linter/rule.py
@@ -69,7 +69,7 @@ class Rule(object):
             if isinstance(result, str):
                 message = result
             matches.append(Match(prev_line_no+1, line,
-                                 file['path'], self, message))
+                                 file['path'], self, message=message))
 
         return matches
 
@@ -84,7 +84,7 @@ class Rule(object):
         results = self.matchtext(file, text)
 
         for line, section, message in results:
-            matches.append(Match(line, section, file['path'], self, message))
+            matches.append(Match(line, section, file['path'], self, message=message))
 
         return matches
 

--- a/tests/unit/TestConfig.py
+++ b/tests/unit/TestConfig.py
@@ -38,7 +38,7 @@ class TestConfig(unittest.TestCase):
 
         # Specify the temporary file as if it was passed as a command line
         # argument.
-        self.config = Configuration(dict(c=self.fp.name))
+        self.config = Configuration({"c": self.fp.name})
 
     def tearDown(self):
         # Close the temporary configuration file.

--- a/tests/unit/TestRunner.py
+++ b/tests/unit/TestRunner.py
@@ -28,7 +28,7 @@ class TestRunner(unittest.TestCase):
         the runner.
         """
         exclude_paths = ['first.sls', 'second.sls']
-        config = Configuration(dict(exclude_paths=exclude_paths))
+        config = Configuration({"exclude_paths": exclude_paths})
         runner = Runner([], 'init.sls', config)
 
         self.assertTrue(

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 isolated_build = True
-envlist = lint,{py37,py38,py39,py310,py311,py312}-install,mypy
+envlist = lint,{py37,py38,py39,py310,py311,py312,py313,py314}-install,mypy
 skip_missing_interpreters = True
 
 [testenv]
@@ -49,6 +49,14 @@ skip_install = {[testenv:install]skip_install}
 commands = {[testenv:install]commands}
 
 [testenv:py312-install]
+skip_install = {[testenv:install]skip_install}
+commands = {[testenv:install]commands}
+
+[testenv:py313-install]
+skip_install = {[testenv:install]skip_install}
+commands = {[testenv:install]commands}
+
+[testenv:py314-install]
 skip_install = {[testenv:install]skip_install}
 commands = {[testenv:install]commands}
 


### PR DESCRIPTION
## Summary
  - Add Python 3.13 and 3.14 to classifiers, tox envs, and CI matrix.
  - Bump pre-commit hooks (old pylint v2.15.9 won't install on 3.14).
  - Fix the pylint warnings the newer pylint surfaces.