### PR TITLE
feat: add --codeclimate output formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Drop Python 3.6 support ([#319](https://github.com/warpnet/salt-lint/pull/319)).
 
 ### Added
+- Add `--codeclimate` output format for GitLab Code Quality reports ([#330](https://github.com/warpnet/salt-lint/issues/330)).
 - Add Python 3.12 support ([#315](https://github.com/warpnet/salt-lint/pull/315)).
 - Lookup configuration file in parent directory ([#305](https://github.com/warpnet/salt-lint/pull/305)).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ The following is the output from `salt-lint --help`, providing an overview of th
 
 ```bash
 usage: salt-lint [-h] [--version] [-L] [-r RULESDIR] [-R] [-t TAGS] [-T] [-v] [-x SKIP_LIST] [--nocolor] [--force-color]
-                 [--exclude EXCLUDE_PATHS] [--json] [--severity] [-c C]
+                 [--exclude EXCLUDE_PATHS] [--json] [--severity] [--codeclimate] [-c C]
                  files [files ...]
 
 positional arguments:
@@ -86,6 +86,7 @@ optional arguments:
                         path to directories or files to skip. This option is repeatable.
   --json                parse the output as JSON
   --severity            add the severity to the standard output
+  --codeclimate         parse the output as CodeClimate / GitLab Code Quality JSON
   -c C                  Specify configuration file to use. Defaults to ".salt-lint"
 ```
 

--- a/saltlint/cli.py
+++ b/saltlint/cli.py
@@ -16,7 +16,7 @@ from saltlint.linter.collection import RulesCollection
 from saltlint.linter.runner import Runner
 
 
-def run(args=None):
+def run(args=None):  # pylint: disable=R0911
     """Run the linter and return the exit code."""
     parser = init_argument_parser()
     options = parser.parse_args(args if args is not None else sys.argv[1:])
@@ -60,7 +60,11 @@ def run(args=None):
         print(collection.listtags())
         return 0
 
-    formatter = initialize_formatter(config)
+    try:
+        formatter = initialize_formatter(config)
+    except SaltLintConfigError as exc:
+        print(exc, file=sys.stderr)
+        return 2
 
     problems = []
     for file_name in file_names:
@@ -129,6 +133,8 @@ def init_argument_parser():
                         help='parse the output as JSON')
     parser.add_argument('--severity', dest='severity', action='store_true', default=False,
                         help='add the severity to the standard output')
+    parser.add_argument('--codeclimate', dest='codeclimate', action='store_true', default=False,
+                        help='parse the output as CodeClimate / GitLab Code Quality JSON')
     parser.add_argument('-c', help='Specify configuration file to use.  Defaults to ".salt-lint"')
 
     return parser
@@ -136,9 +142,15 @@ def init_argument_parser():
 
 def initialize_formatter(config):
     """Return the initialized output formatter based upon the configuration."""
-    if config.json:  # pylint: disable=R1705
+    if config.codeclimate and (config.json or config.severity):
+        raise SaltLintConfigError(
+            "--codeclimate cannot be combined with --json or --severity"
+        )
+    if config.codeclimate:
+        return formatters.CodeClimateFormatter()
+    if config.json:
         return formatters.JsonFormatter()
-    elif config.severity:  # pylint: disable=R1705
+    if config.severity:
         return formatters.SeverityFormatter(config.colored)
     return formatters.Formatter(config.colored)
 

--- a/saltlint/config.py
+++ b/saltlint/config.py
@@ -106,6 +106,11 @@ class Configuration(object):
         if 'severity' in config:
             self.severity = config['severity']
 
+        # Parse codeclimate
+        self.codeclimate = self._options.get('codeclimate', False)
+        if 'codeclimate' in config:
+            self.codeclimate = config['codeclimate']
+
         # Parse rule specific configuration, the configuration can be listed by
         # the rule ID and/or tag.
         self.rules = {}

--- a/saltlint/formatters/__init__.py
+++ b/saltlint/formatters/__init__.py
@@ -4,3 +4,4 @@
 from saltlint.formatters.default import Formatter  # noqa: F401
 from saltlint.formatters.severity import SeverityFormatter  # noqa: F401
 from saltlint.formatters.json import JsonFormatter  # noqa: F401
+from saltlint.formatters.codeclimate import CodeClimateFormatter  # noqa: F401

--- a/saltlint/formatters/codeclimate.py
+++ b/saltlint/formatters/codeclimate.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026 Warpnet B.V.
+
+import hashlib
+import json
+
+from saltlint.formatters.base import BaseFormatter
+
+
+SEVERITY_MAP = {
+    'INFO': 'info',
+    'VERY_LOW': 'minor',
+    'LOW': 'minor',
+    'MEDIUM': 'major',
+    'HIGH': 'critical',
+}
+
+
+class CodeClimateFormatter(BaseFormatter):
+    def process(self, problems, *args, **kwargs):
+        items = [self.format(p) for p in problems]
+        print(json.dumps(items))
+
+    def format(self, problem):
+        identifier = "{}:{}:{}:{}".format(
+            problem.rule.id,
+            problem.filename,
+            problem.linenumber,
+            problem.line,
+        )
+        fingerprint = hashlib.sha256(identifier.encode('utf-8')).hexdigest()
+        return {
+            'description': problem.message,
+            'check_name': problem.rule.id,
+            'fingerprint': fingerprint,
+            'severity': SEVERITY_MAP.get(problem.rule.severity, 'minor'),
+            'location': {
+                'path': problem.filename,
+                'lines': {'begin': problem.linenumber},
+            },
+        }

--- a/tests/unit/TestCodeClimateFormatter.py
+++ b/tests/unit/TestCodeClimateFormatter.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026 Warpnet B.V.
+
+import io
+import json
+import unittest
+from contextlib import redirect_stdout
+
+from saltlint.formatters.codeclimate import CodeClimateFormatter, SEVERITY_MAP
+from saltlint.linter.match import Match
+
+
+class FakeRule:
+    def __init__(self, rule_id, severity, shortdesc='short'):
+        self.id = rule_id
+        self.severity = severity
+        self.shortdesc = shortdesc
+
+
+class TestCodeClimateFormatter(unittest.TestCase):
+
+    def _match(self, *, rule_id='204', severity='HIGH', message='boom',
+               filename='states/foo.sls', linenumber=7, line='bad line'):
+        return Match(linenumber, line, filename,
+                     FakeRule(rule_id, severity), message=message)
+
+    def test_format_shape(self):
+        item = CodeClimateFormatter().format(self._match())
+        self.assertEqual(item['description'], 'boom')
+        self.assertEqual(item['check_name'], '204')
+        self.assertEqual(item['severity'], 'critical')
+        self.assertEqual(item['location'],
+                         {'path': 'states/foo.sls', 'lines': {'begin': 7}})
+        self.assertEqual(len(item['fingerprint']), 64)  # sha256 hex
+
+    def test_severity_mapping(self):
+        formatter = CodeClimateFormatter()
+        for salt_sev, cc_sev in SEVERITY_MAP.items():
+            with self.subTest(severity=salt_sev):
+                self.assertEqual(
+                    formatter.format(self._match(severity=salt_sev))['severity'],
+                    cc_sev,
+                )
+
+    def test_unknown_severity_defaults_to_minor(self):
+        item = CodeClimateFormatter().format(self._match(severity='WEIRD'))
+        self.assertEqual(item['severity'], 'minor')
+
+    def test_fingerprint_is_stable_and_unique(self):
+        formatter = CodeClimateFormatter()
+        a1 = formatter.format(self._match())['fingerprint']
+        a2 = formatter.format(self._match())['fingerprint']
+        b = formatter.format(self._match(linenumber=8))['fingerprint']
+        self.assertEqual(a1, a2)
+        self.assertNotEqual(a1, b)
+
+    def test_process_emits_json_array(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            CodeClimateFormatter().process([self._match(), self._match(linenumber=9)])
+        items = json.loads(buf.getvalue())
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0]['location']['lines']['begin'], 7)
+        self.assertEqual(items[1]['location']['lines']['begin'], 9)


### PR DESCRIPTION
Adds a CodeClimate / GitLab Code Quality JSON output format, exposed via the new --codeclimate CLI flag and config option. Salt-lint severity levels are mapped to CodeClimate severities (INFO->info, VERY_LOW/LOW->minor, MEDIUM->major, HIGH->critical). Combining --codeclimate with --json or --severity now exits with an error.

Closes #330