### PR TITLE
chore: bump Dockerfile base image to alpine 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,23 @@
-FROM alpine:3.11 as builder
+FROM alpine:3.22 as builder
 
 # hadolint ignore=DL3018
 RUN set -eux \
  && apk add --no-cache \
  bash gcc \
- python3 python3-dev
+ python3 python3-dev py3-pip
 
 WORKDIR /src
 
 COPY . /src/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux \
- && python3 -m pip install . \
+ && python3 -m pip install --break-system-packages . \
  && salt-lint --version \
  && find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
  && find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
 
-FROM alpine:3.11 as production
+FROM alpine:3.22 as production
 LABEL maintainer="info@warpnet.nl" \
       repo="https://github.com/warpnet/salt-lint"
 # hadolint ignore=DL3018
@@ -29,7 +29,7 @@ RUN set -eux \
  && find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf \
  && addgroup -S -g 800 linter \
  && adduser -S -u 800 -S -H -D -G linter linter
-COPY --from=builder /usr/lib/python3.8/site-packages/ /usr/lib/python3.8/site-packages/
+COPY --from=builder /usr/lib/python3.12/site-packages/ /usr/lib/python3.12/site-packages/
 COPY --from=builder /usr/bin/salt-lint /usr/bin/salt-lint
 WORKDIR /data
 USER linter


### PR DESCRIPTION
Alpine 3.22 ships Python 3.12 (replacing 3.8). Adds py3-pip since pip is no longer bundled with the python3 package, and passes --break-system-packages to satisfy PEP 668 inside the build stage.